### PR TITLE
PlainDB for multi-trie multi-hash

### DIFF
--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-db"
-version = "0.9.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2.0"

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -91,12 +91,14 @@ pub trait PlainDBRef<K, V> {
 	fn contains(&self, key: &K) -> bool;
 }
 
+#[cfg(feature = "std")]
 impl<'a, K, V> PlainDBRef<K, V> for &'a PlainDB<K, V> {
 	fn keys(&self) -> HashMap<K, i32> { PlainDB::keys(*self) }
 	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
 	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
 }
 
+#[cfg(feature = "std")]
 impl<'a, K, V> PlainDBRef<K, V> for &'a mut PlainDB<K, V> {
 	fn keys(&self) -> HashMap<K, i32> { PlainDB::keys(*self) }
 	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
@@ -143,12 +145,14 @@ pub trait HashDBRef<H: Hasher, T> {
 	fn contains(&self, key: &H::Out) -> bool;
 }
 
+#[cfg(feature = "std")]
 impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a HashDB<H, T> {
 	fn keys(&self) -> HashMap<H::Out, i32> { HashDB::keys(*self) }
 	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
 	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
 }
 
+#[cfg(feature = "std")]
 impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut HashDB<H, T> {
 	fn keys(&self) -> HashMap<H::Out, i32> { HashDB::keys(*self) }
 	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -77,6 +77,32 @@ pub trait PlainDB<K, V>: Send + Sync + AsPlainDB<K, V> {
 	fn remove(&mut self, key: &K);
 }
 
+/// Trait for immutable reference of PlainDB.
+#[cfg(feature = "std")]
+pub trait PlainDBRef<K, V> {
+	/// Get the keys in the database together with number of underlying references.
+	fn keys(&self) -> HashMap<K, i32>;
+
+	/// Look up a given hash into the bytes that hash to it, returning None if the
+	/// hash is not known.
+	fn get(&self, key: &K) -> Option<V>;
+
+	/// Check for the existance of a hash-key.
+	fn contains(&self, key: &K) -> bool;
+}
+
+impl<'a, K, V> PlainDBRef<K, V> for &'a PlainDB<K, V> {
+	fn keys(&self) -> HashMap<K, i32> { PlainDB::keys(*self) }
+	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
+	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
+}
+
+impl<'a, K, V> PlainDBRef<K, V> for &'a mut PlainDB<K, V> {
+	fn keys(&self) -> HashMap<K, i32> { PlainDB::keys(*self) }
+	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
+	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
+}
+
 /// Trait modelling datastore keyed by a hash defined by the `Hasher`.
 #[cfg(feature = "std")]
 pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
@@ -101,6 +127,32 @@ pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 	/// Remove a datum previously inserted. Insertions can be "owed" such that the same number of `insert()`s may
 	/// happen without the data being eventually being inserted into the DB. It can be "owed" more than once.
 	fn remove(&mut self, key: &H::Out);
+}
+
+/// Trait for immutable reference of HashDB.
+#[cfg(feature = "std")]
+pub trait HashDBRef<H: Hasher, T> {
+	/// Get the keys in the database together with number of underlying references.
+	fn keys(&self) -> HashMap<H::Out, i32>;
+
+	/// Look up a given hash into the bytes that hash to it, returning None if the
+	/// hash is not known.
+	fn get(&self, key: &H::Out) -> Option<T>;
+
+	/// Check for the existance of a hash-key.
+	fn contains(&self, key: &H::Out) -> bool;
+}
+
+impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a HashDB<H, T> {
+	fn keys(&self) -> HashMap<H::Out, i32> { HashDB::keys(*self) }
+	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
+	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
+}
+
+impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut HashDB<H, T> {
+	fn keys(&self) -> HashMap<H::Out, i32> { HashDB::keys(*self) }
+	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
+	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
 }
 
 /// Upcast trait for HashDB.

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -55,9 +55,6 @@ pub trait Hasher: Sync + Send {
 /// one value.
 #[cfg(feature = "std")]
 pub trait PlainDB<K, V>: Send + Sync + AsPlainDB<K, V> {
-	/// Get the keys in the database together with number of underlying references.
-	fn keys(&self) -> HashMap<K, i32>;
-
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
 	fn get(&self, key: &K) -> Option<V>;
@@ -80,9 +77,6 @@ pub trait PlainDB<K, V>: Send + Sync + AsPlainDB<K, V> {
 /// Trait for immutable reference of PlainDB.
 #[cfg(feature = "std")]
 pub trait PlainDBRef<K, V> {
-	/// Get the keys in the database together with number of underlying references.
-	fn keys(&self) -> HashMap<K, i32>;
-
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
 	fn get(&self, key: &K) -> Option<V>;
@@ -93,14 +87,12 @@ pub trait PlainDBRef<K, V> {
 
 #[cfg(feature = "std")]
 impl<'a, K, V> PlainDBRef<K, V> for &'a PlainDB<K, V> {
-	fn keys(&self) -> HashMap<K, i32> { PlainDB::keys(*self) }
 	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
 	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
 }
 
 #[cfg(feature = "std")]
 impl<'a, K, V> PlainDBRef<K, V> for &'a mut PlainDB<K, V> {
-	fn keys(&self) -> HashMap<K, i32> { PlainDB::keys(*self) }
 	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
 	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
 }
@@ -108,9 +100,6 @@ impl<'a, K, V> PlainDBRef<K, V> for &'a mut PlainDB<K, V> {
 /// Trait modelling datastore keyed by a hash defined by the `Hasher`.
 #[cfg(feature = "std")]
 pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
-	/// Get the keys in the database together with number of underlying references.
-	fn keys(&self) -> HashMap<H::Out, i32>;
-
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
 	fn get(&self, key: &H::Out) -> Option<T>;
@@ -134,9 +123,6 @@ pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 /// Trait for immutable reference of HashDB.
 #[cfg(feature = "std")]
 pub trait HashDBRef<H: Hasher, T> {
-	/// Get the keys in the database together with number of underlying references.
-	fn keys(&self) -> HashMap<H::Out, i32>;
-
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
 	fn get(&self, key: &H::Out) -> Option<T>;
@@ -147,14 +133,12 @@ pub trait HashDBRef<H: Hasher, T> {
 
 #[cfg(feature = "std")]
 impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a HashDB<H, T> {
-	fn keys(&self) -> HashMap<H::Out, i32> { HashDB::keys(*self) }
 	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
 	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
 }
 
 #[cfg(feature = "std")]
 impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut HashDB<H, T> {
-	fn keys(&self) -> HashMap<H::Out, i32> { HashDB::keys(*self) }
 	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
 	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
 }

--- a/hash256-std-hasher/Cargo.toml
+++ b/hash256-std-hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash256-std-hasher"
 description = "Standard library hasher for 256-bit prehashed keys."
-version = "0.9.1"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 homepage = "https://github.com/paritytech/trie"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.9.1"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = "0.4"
-hash-db = { path = "../hash-db", version = "0.9.0"}
+hash-db = { path = "../hash-db", version = "0.11.0"}
 
 [dev-dependencies]
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.2.1"}
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0"}
 criterion = "0.2.8"
 
 [[bench]]

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -18,7 +18,7 @@ extern crate hash_db;
 extern crate heapsize;
 #[cfg(test)] extern crate keccak_hasher;
 
-use hash_db::{HashDB, Hasher as KeyHasher, AsHashDB};
+use hash_db::{HashDB, PlainDB, Hasher as KeyHasher, AsHashDB, AsPlainDB};
 use heapsize::HeapSizeOf;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -42,9 +42,9 @@ type FastMap<H, T> = HashMap<<H as KeyHasher>::Out, T, hash::BuildHasherDefault<
 /// extern crate keccak_hasher;
 /// extern crate memory_db;
 ///
-/// use hash_db::*;
+/// use hash_db::{Hasher, HashDB};
 /// use keccak_hasher::KeccakHasher;
-/// use memory_db::*;
+/// use memory_db::MemoryDB;
 /// fn main() {
 ///   let mut m = MemoryDB::<KeccakHasher, Vec<u8>>::default();
 ///   let d = "Hello world!".as_bytes();
@@ -121,7 +121,6 @@ where
 }
 
 impl<'a, H: KeyHasher, T> MemoryDB<H, T> where T: From<&'a [u8]> {
-
 	/// Create a new `MemoryDB` from a given null key/data
 	pub fn from_null_node(null_key: &'a [u8], null_node_data: T) -> Self {
 		MemoryDB {
@@ -148,9 +147,9 @@ impl<'a, H: KeyHasher, T> MemoryDB<H, T> where T: From<&'a [u8]> {
 	/// extern crate keccak_hasher;
 	/// extern crate memory_db;
 	///
-	/// use hash_db::*;
+	/// use hash_db::{Hasher, HashDB};
 	/// use keccak_hasher::KeccakHasher;
-	/// use memory_db::*;
+	/// use memory_db::MemoryDB;
 	///
 	/// fn main() {
 	///   let mut m = MemoryDB::<KeccakHasher, Vec<u8>>::default();
@@ -218,7 +217,7 @@ where
 	}
 }
 
-impl<H, T> HashDB<H, T> for MemoryDB<H, T>
+impl<H, T> PlainDB<H::Out, T> for MemoryDB<H, T>
 where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
@@ -234,10 +233,6 @@ where
 	}
 
 	fn get(&self, key: &H::Out) -> Option<T> {
-		if key == &self.hashed_null_node {
-			return Some(self.null_node_data.clone());
-		}
-
 		match self.data.get(key) {
 			Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
 			_ => None
@@ -245,21 +240,13 @@ where
 	}
 
 	fn contains(&self, key: &H::Out) -> bool {
-		if key == &self.hashed_null_node {
-			return true;
-		}
-
 		match self.data.get(key) {
 			Some(&(_, x)) if x > 0 => true,
 			_ => false
 		}
 	}
 
-	fn emplace(&mut self, key:H::Out, value: T) {
-		if value == self.null_node_data {
-			return;
-		}
-
+	fn emplace(&mut self, key: H::Out, value: T) {
 		match self.data.entry(key) {
 			Entry::Occupied(mut entry) => {
 				let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
@@ -274,31 +261,7 @@ where
 		}
 	}
 
-	fn insert(&mut self, value: &[u8]) -> H::Out {
-		if T::from(value) == self.null_node_data {
-			return self.hashed_null_node.clone();
-		}
-		let key = H::hash(value);
-		match self.data.entry(key) {
-			Entry::Occupied(mut entry) => {
-				let &mut (ref mut old_value, ref mut rc) = entry.get_mut();
-				if *rc <= 0 {
-					*old_value = value.into();
-				}
-				*rc += 1;
-			},
-			Entry::Vacant(entry) => {
-				entry.insert((value.into(), 1));
-			},
-		}
-		key
-	}
-
 	fn remove(&mut self, key: &H::Out) {
-		if key == &self.hashed_null_node {
-			return;
-		}
-
 		match self.data.entry(*key) {
 			Entry::Occupied(mut entry) => {
 				let &mut (_, ref mut rc) = entry.get_mut();
@@ -309,7 +272,69 @@ where
 			},
 		}
 	}
+}
 
+impl<H, T> HashDB<H, T> for MemoryDB<H, T>
+where
+	H: KeyHasher,
+	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+{
+	fn keys(&self) -> HashMap<H::Out, i32> {
+		PlainDB::keys(self)
+	}
+
+	fn get(&self, key: &H::Out) -> Option<T> {
+		if key == &self.hashed_null_node {
+			return Some(self.null_node_data.clone());
+		}
+
+		PlainDB::get(self, key)
+	}
+
+	fn contains(&self, key: &H::Out) -> bool {
+		if key == &self.hashed_null_node {
+			return true;
+		}
+
+		PlainDB::contains(self, key)
+	}
+
+	fn emplace(&mut self, key: H::Out, value: T) {
+		if value == self.null_node_data {
+			return;
+		}
+
+		PlainDB::emplace(self, key, value)
+	}
+
+	fn insert(&mut self, value: &[u8]) -> H::Out {
+		if T::from(value) == self.null_node_data {
+			return self.hashed_null_node.clone();
+		}
+
+		let key = H::hash(value);
+		PlainDB::emplace(self, key.clone(), value.into());
+
+		key
+	}
+
+	fn remove(&mut self, key: &H::Out) {
+		if key == &self.hashed_null_node {
+			return;
+		}
+
+		PlainDB::remove(self, key)
+	}
+
+}
+
+impl<H, T> AsPlainDB<H::Out, T> for MemoryDB<H, T>
+where
+	H: KeyHasher,
+	T: Default + PartialEq<T> + for<'a> From<&'a[u8]> + Clone + Send + Sync,
+{
+	fn as_plain_db(&self) -> &PlainDB<H::Out, T> { self }
+	fn as_plain_db_mut(&mut self) -> &mut PlainDB<H::Out, T> { self }
 }
 
 impl<H, T> AsHashDB<H, T> for MemoryDB<H, T>
@@ -323,7 +348,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use super::{MemoryDB, HashDB, KeyHasher};
 	use keccak_hasher::KeccakHasher;
 
 	#[test]

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -203,6 +203,17 @@ impl<'a, H: KeyHasher, T> MemoryDB<H, T> where T: From<&'a [u8]> {
 			}
 		}
 	}
+
+	/// Get the keys in the database together with number of underlying references.
+	pub fn keys(&self) -> HashMap<H::Out, i32> {
+		self.data.iter()
+			.filter_map(|(k, v)| if v.1 != 0 {
+				Some((*k, v.1))
+			} else {
+				None
+			})
+			.collect()
+	}
 }
 
 impl<H, T> MemoryDB<H, T>
@@ -222,16 +233,6 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 {
-	fn keys(&self) -> HashMap<H::Out, i32> {
-		self.data.iter()
-			.filter_map(|(k, v)| if v.1 != 0 {
-				Some((*k, v.1))
-			} else {
-				None
-			})
-			.collect()
-	}
-
 	fn get(&self, key: &H::Out) -> Option<T> {
 		match self.data.get(key) {
 			Some(&(ref d, rc)) if rc > 0 => Some(d.clone()),
@@ -279,7 +280,6 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 {
-	fn keys(&self) -> HashMap<H::Out, i32> { PlainDB::keys(self) }
 	fn get(&self, key: &H::Out) -> Option<T> { PlainDB::get(self, key) }
 	fn contains(&self, key: &H::Out) -> bool { PlainDB::contains(self, key) }
 }
@@ -289,10 +289,6 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 {
-	fn keys(&self) -> HashMap<H::Out, i32> {
-		PlainDB::keys(self)
-	}
-
 	fn get(&self, key: &H::Out) -> Option<T> {
 		if key == &self.hashed_null_node {
 			return Some(self.null_node_data.clone());
@@ -342,7 +338,6 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 {
-	fn keys(&self) -> HashMap<H::Out, i32> { HashDB::keys(self) }
 	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(self, key) }
 	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(self, key) }
 }

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -18,7 +18,7 @@ extern crate hash_db;
 extern crate heapsize;
 #[cfg(test)] extern crate keccak_hasher;
 
-use hash_db::{HashDB, PlainDB, Hasher as KeyHasher, AsHashDB, AsPlainDB};
+use hash_db::{HashDB, HashDBRef, PlainDB, PlainDBRef, Hasher as KeyHasher, AsHashDB, AsPlainDB};
 use heapsize::HeapSizeOf;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -274,6 +274,16 @@ where
 	}
 }
 
+impl<H, T> PlainDBRef<H::Out, T> for MemoryDB<H, T>
+where
+	H: KeyHasher,
+	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+{
+	fn keys(&self) -> HashMap<H::Out, i32> { PlainDB::keys(self) }
+	fn get(&self, key: &H::Out) -> Option<T> { PlainDB::get(self, key) }
+	fn contains(&self, key: &H::Out) -> bool { PlainDB::contains(self, key) }
+}
+
 impl<H, T> HashDB<H, T> for MemoryDB<H, T>
 where
 	H: KeyHasher,
@@ -325,7 +335,16 @@ where
 
 		PlainDB::remove(self, key)
 	}
+}
 
+impl<H, T> HashDBRef<H, T> for MemoryDB<H, T>
+where
+	H: KeyHasher,
+	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
+{
+	fn keys(&self) -> HashMap<H::Out, i32> { HashDB::keys(self) }
+	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(self, key) }
+	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(self, key) }
 }
 
 impl<H, T> AsPlainDB<H::Out, T> for MemoryDB<H, T>

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.2.1"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -8,5 +8,5 @@ license = "Apache-2.0"
 
 [dependencies]
 tiny-keccak = "1.4.2"
-hash-db = { path = "../../hash-db", version = "0.9.0" }
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.9.1" }
+hash-db = { path = "../../hash-db", version = "0.11.0" }
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.11.0" }

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "reference-trie"
-version = "0.2.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.9.0"}
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.9.1" }
-keccak-hasher = { path = "../keccak-hasher", version = "0.2.1" }
-trie-db = { path = "../../trie-db", version = "0.9.1"}
-trie-root = { path = "../../trie-root", version = "0.9.1" }
+hash-db = { path = "../../hash-db" , version = "0.11.0"}
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.11.0" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.11.0" }
+trie-db = { path = "../../trie-db", version = "0.11.0"}
+trie-root = { path = "../../trie-root", version = "0.11.0" }
 parity-codec = "3.0"
 parity-codec-derive = "3.0"
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.10.0" }
+trie-bench = { path = "../trie-bench", version = "0.11.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.2.1" }
-trie-standardmap = { path = "../trie-standardmap", version  = "0.9.1" }
-hash-db = { path = "../../hash-db" , version = "0.9.0"}
-memory-db = { path = "../../memory-db", version = "0.9.1" }
-trie-root = { path = "../../trie-root", version = "0.9.1" }
-trie-db = { path = "../../trie-db", version = "0.9.1" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.11.0" }
+trie-standardmap = { path = "../trie-standardmap", version  = "0.11.0" }
+hash-db = { path = "../../hash-db" , version = "0.11.0"}
+memory-db = { path = "../../memory-db", version = "0.11.0" }
+trie-root = { path = "../../trie-root", version = "0.11.0" }
+trie-db = { path = "../../trie-db", version = "0.11.0" }
 criterion = "0.2.8"
 parity-codec = "3.0"

--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "trie-standardmap"
 description = "Standard test map for profiling tries"
-version = "0.9.1"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.2.1"}
-hash-db = { path = "../../hash-db" , version = "0.9.0"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.11.0"}
+hash-db = { path = "../../hash-db" , version = "0.11.0"}
 criterion = "0.2.8"

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.9.1"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/parity-common"
@@ -10,16 +10,16 @@ license = "Apache-2.0"
 log = "0.4"
 rand = "0.6"
 elastic-array = "0.10"
-hash-db = { path = "../hash-db" , version = "0.9.0"}
+hash-db = { path = "../hash-db" , version = "0.11.0"}
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.9.1" }
-trie-root = { path = "../trie-root", version = "0.9.1"}
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.9.1" }
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.2.1" }
+memory-db = { path = "../memory-db", version = "0.11.0" }
+trie-root = { path = "../trie-root", version = "0.11.0"}
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.2.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.11.0" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use hash_db::{HashDB, Hasher};
+use hash_db::{HashDBRef, Hasher};
 use super::{Result, DBValue, TrieDB, Trie, TrieDBIterator, TrieItem, TrieIterator, Query};
 use node_codec::NodeCodec;
 
@@ -21,32 +21,32 @@ use node_codec::NodeCodec;
 ///
 /// Use it as a `Trie` or `TrieMut` trait object.
 pub struct FatDB<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H>
 {
 	raw: TrieDB<'db, H, C>,
 }
 
 impl<'db, H, C> FatDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db HashDB<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn new(db: &'db HashDBRef<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
 		Ok(FatDB { raw: TrieDB::new(db, root)? })
 	}
 
 	/// Get the backing database.
-	pub fn db(&self) -> &HashDB<H, DBValue> { self.raw.db() }
+	pub fn db(&self) -> &HashDBRef<H, DBValue> { self.raw.db() }
 }
 
 impl<'db, H, C> Trie<H, C> for FatDB<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn root(&self) -> &H::Out { self.raw.root() }
@@ -68,8 +68,8 @@ where
 
 /// Itarator over inserted pairs of key values.
 pub struct FatDBIterator<'db, H, C>
-where 
-	H: Hasher + 'db, 
+where
+	H: Hasher + 'db,
 	C: NodeCodec<H> + 'db
 {
 	trie_iterator: TrieDBIterator<'db, H, C>,
@@ -77,8 +77,8 @@ where
 }
 
 impl<'db, H, C> FatDBIterator<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	/// Creates new iterator.
@@ -91,8 +91,8 @@ where
 }
 
 impl<'db, H, C> TrieIterator<H, C> for FatDBIterator<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	fn seek(&mut self, key: &[u8]) -> Result<(), H::Out, C::Error> {
@@ -102,8 +102,8 @@ where
 }
 
 impl<'db, H, C> Iterator for FatDBIterator<'db, H, C>
-where 
-	H: Hasher, 
+where
+	H: Hasher,
 	C: NodeCodec<H>
 {
 	type Item = TrieItem<'db, H::Out, C::Error>;

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -52,7 +52,7 @@ mod nibblevec;
 mod nibbleslice;
 mod node_codec;
 
-pub use hash_db::{HashDB, Hasher};
+pub use hash_db::{HashDB, HashDBRef, Hasher};
 pub use self::triedb::{TrieDB, TrieDBIterator};
 pub use self::triedbmut::{TrieDBMut, ChildReference};
 pub use self::sectriedbmut::SecTrieDBMut;
@@ -291,7 +291,7 @@ where
 	/// Create new immutable instance of Trie.
 	pub fn readonly(
 		&self,
-		db: &'db HashDB<H, DBValue>,
+		db: &'db HashDBRef<H, DBValue>,
 		root: &'db H::Out
 	) -> Result<TrieKinds<'db, H, C>, H::Out, <C as NodeCodec<H>>::Error> {
 		match self.spec {

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -14,7 +14,7 @@
 
 //! Trie lookup via HashDB.
 
-use hash_db::{HashDB, Hasher};
+use hash_db::{HashDBRef, Hasher};
 use nibbleslice::NibbleSlice;
 use node::Node;
 use node_codec::NodeCodec;
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 /// Trie lookup helper object.
 pub struct Lookup<'a, H: Hasher + 'a, C: NodeCodec<H>, Q: Query<H>> {
 	/// database to query from.
-	pub db: &'a HashDB<H, DBValue>,
+	pub db: &'a HashDBRef<H, DBValue>,
 	/// Query object to record nodes and transform data.
 	pub query: Q,
 	/// Hash to start at
@@ -34,8 +34,8 @@ pub struct Lookup<'a, H: Hasher + 'a, C: NodeCodec<H>, Q: Query<H>> {
 
 impl<'a, H, C, Q> Lookup<'a, H, C, Q>
 where
-	H: Hasher + 'a,
-	C: NodeCodec<H> + 'a,
+	H: Hasher,
+	C: NodeCodec<H>,
 	Q: Query<H>,
 {
 	/// Look up the given key. If the value is found, it will be passed to the given

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use hash_db::{HashDB, Hasher};
+use hash_db::{HashDBRef, Hasher};
 use super::triedb::TrieDB;
 use super::{Result, DBValue, Trie, TrieItem, TrieIterator, Query};
 use node_codec::NodeCodec;
@@ -38,7 +38,7 @@ where
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
 	/// Returns an error if root does not exist.
-	pub fn new(db: &'db HashDB<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn new(db: &'db HashDBRef<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
 		Ok(SecTrieDB { raw: TrieDB::new(db, root)? })
 	}
 

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -969,7 +969,7 @@ mod tests {
 	use memory_db::MemoryDB;
 	use hash_db::{Hasher, HashDB};
 	use keccak_hasher::KeccakHasher;
-	use reference_trie::{RefTrieDBMut, RefTrieDB, Trie, TrieMut, NodeCodec,
+	use reference_trie::{RefTrieDBMut, TrieMut, NodeCodec,
 		ReferenceNodeCodec, ref_trie_root};
 
 	fn populate_trie<'db>(

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -387,8 +387,8 @@ where
 		let mut handle = handle;
 		loop {
 			let (mid, child) = match *handle {
-				NodeHandle::Hash(ref hash) => return Lookup{
-					db: &*self.db,
+				NodeHandle::Hash(ref hash) => return Lookup {
+					db: &self.db,
 					query: DBValue::from_slice,
 					hash: hash.clone(),
 					marker: PhantomData::<C>,

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.9.1"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 categories = [ "no-std" ]
 
 [dependencies]
-hash-db = { path = "../hash-db", default-features = false, version = "0.9.0"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
 
 [dev-dependencies]
 hex-literal = "0.1"
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.2.1" }
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.9.1" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.2.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.11.0" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This lays out the traits needed to solve https://github.com/paritytech/substrate/issues/872#issuecomment-436816629, to support multiple hashing algorithms in multi-trie.

Because we can't know how many children tries are created, multi-trie needs to write all hashdb values into a single storage. To support multiple hash algorithms, the length of the hash might also be different, while the underlying data store might expect a fixed length hash. With traits in this PR, we can fix both of the issues:

* Pass `PlainDB` reference in children delta trie root generation. The generation function wraps `PlainDB` into another `HashDB` of the targeted hash algorithm to continue the operation.
* If the generation function is really sure that targeted hash and original hash have the same length (and hashes won't collide), then the wrapper can directly use targeted hash as original hash and pass it back to `PlainDB`.
* Otherwise, the wrapper can use original hash algorithm to do `H::hash(key)` before passing it back to `PlainDB`.

This PR should be backward-compatible. The only case where it breaks is if a file tries to do `use hash_db::*`.