### PR TITLE
update codec and new release

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -12,11 +12,11 @@ hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.9.1" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.2.1" }
 trie-db = { path = "../../trie-db", version = "0.9.1"}
 trie-root = { path = "../../trie-root", version = "0.9.1" }
-parity-codec = "2.2"
-parity-codec-derive = "2.2"
+parity-codec = "3.0"
+parity-codec-derive = "3.0"
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.9.1" }
+trie-bench = { path = "../trie-bench", version = "0.10.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
@@ -13,4 +13,4 @@ memory-db = { path = "../../memory-db", version = "0.9.1" }
 trie-root = { path = "../../trie-root", version = "0.9.1" }
 trie-db = { path = "../../trie-db", version = "0.9.1" }
 criterion = "0.2.8"
-parity-codec = "2.2"
+parity-codec = "3.0"

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -19,7 +19,7 @@ trie-root = { path = "../trie-root", version = "0.9.1"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.9.1" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.2.1" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.1.1" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.2.0" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -15,7 +15,7 @@ hex-literal = "0.1"
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.2.1" }
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.9.1" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.1.1" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.2.0" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This update codec and make new release of trie-bench and reference-tri

I only need trie-bench release for substrate so I don't know if we release a new one for reference-trie also.

as it is only dev depencencies of trie-root and trie-db we don't need to update them.