### PR TITLE
Add reference-trie to cargo workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
 	"memory-db",
 	"hash256-std-hasher",
 	"test-support/keccak-hasher",
+	"test-support/reference-trie",
 	"test-support/trie-standardmap",
 	"test-support/trie-bench",
 	"trie-db",


### PR DESCRIPTION
So that its tests are included when running `cargo test --all`.