### PR TITLE
Node key prefixes in the database

### DIFF
--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-db"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2.0"

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -20,8 +20,6 @@
 #[cfg(feature = "std")]
 use std::fmt::Debug;
 #[cfg(feature = "std")]
-use std::collections::HashMap;
-#[cfg(feature = "std")]
 use std::hash;
 #[cfg(feature = "std")]
 pub trait DebugIfStd: Debug {}
@@ -102,22 +100,22 @@ impl<'a, K, V> PlainDBRef<K, V> for &'a mut PlainDB<K, V> {
 pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
-	fn get(&self, key: &H::Out) -> Option<T>;
+	fn get(&self, key: &H::Out, prefix: &[u8]) -> Option<T>;
 
 	/// Check for the existance of a hash-key.
-	fn contains(&self, key: &H::Out) -> bool;
+	fn contains(&self, key: &H::Out, prefix: &[u8]) -> bool;
 
 	/// Insert a datum item into the DB and return the datum's hash for a later lookup. Insertions
 	/// are counted and the equivalent number of `remove()`s must be performed before the data
 	/// is considered dead.
-	fn insert(&mut self, value: &[u8]) -> H::Out;
+	fn insert(&mut self, prefix: &[u8], value: &[u8]) -> H::Out;
 
 	/// Like `insert()`, except you provide the key and the data is all moved.
-	fn emplace(&mut self, key: H::Out, value: T);
+	fn emplace(&mut self, key: H::Out, prefix: &[u8], value: T);
 
 	/// Remove a datum previously inserted. Insertions can be "owed" such that the same number of `insert()`s may
 	/// happen without the data being eventually being inserted into the DB. It can be "owed" more than once.
-	fn remove(&mut self, key: &H::Out);
+	fn remove(&mut self, key: &H::Out, prefix: &[u8]);
 }
 
 /// Trait for immutable reference of HashDB.
@@ -125,22 +123,22 @@ pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 pub trait HashDBRef<H: Hasher, T> {
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
-	fn get(&self, key: &H::Out) -> Option<T>;
+	fn get(&self, key: &H::Out, prefix: &[u8]) -> Option<T>;
 
 	/// Check for the existance of a hash-key.
-	fn contains(&self, key: &H::Out) -> bool;
+	fn contains(&self, key: &H::Out, prefix: &[u8]) -> bool;
 }
 
 #[cfg(feature = "std")]
 impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a HashDB<H, T> {
-	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
-	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
+	fn get(&self, key: &H::Out, prefix: &[u8]) -> Option<T> { HashDB::get(*self, key, prefix) }
+	fn contains(&self, key: &H::Out, prefix: &[u8]) -> bool { HashDB::contains(*self, key, prefix) }
 }
 
 #[cfg(feature = "std")]
 impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut HashDB<H, T> {
-	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
-	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
+	fn get(&self, key: &H::Out, prefix: &[u8]) -> Option<T> { HashDB::get(*self, key, prefix) }
+	fn contains(&self, key: &H::Out, prefix: &[u8]) -> bool { HashDB::contains(*self, key, prefix) }
 }
 
 /// Upcast trait for HashDB.

--- a/hash256-std-hasher/Cargo.toml
+++ b/hash256-std-hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash256-std-hasher"
 description = "Standard library hasher for 256-bit prehashed keys."
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 homepage = "https://github.com/paritytech/trie"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = "0.4"
-hash-db = { path = "../hash-db", version = "0.11.0"}
+hash-db = { path = "../hash-db", version = "0.12.0"}
 
 [dev-dependencies]
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0"}
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.0"}
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -8,5 +8,5 @@ license = "Apache-2.0"
 
 [dependencies]
 tiny-keccak = "1.4.2"
-hash-db = { path = "../../hash-db", version = "0.11.0" }
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.11.0" }
+hash-db = { path = "../../hash-db", version = "0.12.0" }
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.0" }

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "reference-trie"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.11.0"}
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.11.0" }
-keccak-hasher = { path = "../keccak-hasher", version = "0.11.0" }
-trie-db = { path = "../../trie-db", version = "0.11.0"}
-trie-root = { path = "../../trie-root", version = "0.11.0" }
+hash-db = { path = "../../hash-db" , version = "0.12.0"}
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.0" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.0" }
+trie-db = { path = "../../trie-db", version = "0.12.0"}
+trie-root = { path = "../../trie-root", version = "0.12.0" }
 parity-codec = "3.0"
 parity-codec-derive = "3.0"
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.11.0" }
+trie-bench = { path = "../trie-bench", version = "0.12.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -161,7 +161,6 @@ impl Decode for NodeHeader {
 			BRANCH_NODE_WITH_VALUE => NodeHeader::Branch(true),
 			i @ LEAF_NODE_OFFSET ... LEAF_NODE_LAST => NodeHeader::Leaf((i - LEAF_NODE_OFFSET) as usize),
 			i @ EXTENSION_NODE_OFFSET ... EXTENSION_NODE_LAST => NodeHeader::Extension((i - EXTENSION_NODE_OFFSET) as usize),
-			_ => unreachable!(),
 		})
 	}
 }

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.11.0" }
-trie-standardmap = { path = "../trie-standardmap", version  = "0.11.0" }
-hash-db = { path = "../../hash-db" , version = "0.11.0"}
-memory-db = { path = "../../memory-db", version = "0.11.0" }
-trie-root = { path = "../../trie-root", version = "0.11.0" }
-trie-db = { path = "../../trie-db", version = "0.11.0" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.0" }
+trie-standardmap = { path = "../trie-standardmap", version  = "0.12.0" }
+hash-db = { path = "../../hash-db" , version = "0.12.0"}
+memory-db = { path = "../../memory-db", version = "0.12.0" }
+trie-root = { path = "../../trie-root", version = "0.12.0" }
+trie-db = { path = "../../trie-db", version = "0.12.0" }
 criterion = "0.2.8"
 parity-codec = "3.0"

--- a/test-support/trie-bench/src/lib.rs
+++ b/test-support/trie-bench/src/lib.rs
@@ -27,7 +27,7 @@ use parity_codec::{Encode, Compact};
 use criterion::{Criterion, black_box, Fun};
 use keccak_hasher::KeccakHasher;
 use hash_db::Hasher;
-use memory_db::MemoryDB;
+use memory_db::{MemoryDB, HashKey};
 use trie_db::{NodeCodec, TrieDB, TrieDBMut, Trie, TrieMut};
 use trie_root::{TrieStream, trie_root};
 use trie_standardmap::*;
@@ -54,7 +54,7 @@ where
 			trie_root::<H, S, _, _, _>(d.0.clone())
 		})),
 		Fun::new("Fill", |b, d: &TrieInsertionList| b.iter(&mut ||{
-			let mut memdb = MemoryDB::new(&N::empty_node()[..]);
+			let mut memdb = MemoryDB::<_, HashKey<_>, _>::new(&N::empty_node()[..]);
 			let mut root = H::Out::default();
 			let mut t = TrieDBMut::<H, N>::new(&mut memdb, &mut root);
 			for i in d.0.iter() {
@@ -62,7 +62,7 @@ where
 			}
 		})),
 		Fun::new("Iter", |b, d: &TrieInsertionList| {
-			let mut memdb = MemoryDB::new(&N::empty_node()[..]);
+			let mut memdb = MemoryDB::<_, HashKey<_>, _>::new(&N::empty_node()[..]);
 			let mut root = H::Out::default();
 			{
 				let mut t = TrieDBMut::<H, N>::new(&mut memdb, &mut root);

--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "trie-standardmap"
 description = "Standard test map for profiling tries"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.11.0"}
-hash-db = { path = "../../hash-db" , version = "0.11.0"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.0"}
+hash-db = { path = "../../hash-db" , version = "0.12.0"}
 criterion = "0.2.8"

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/parity-common"
@@ -10,16 +10,16 @@ license = "Apache-2.0"
 log = "0.4"
 rand = "0.6"
 elastic-array = "0.10"
-hash-db = { path = "../hash-db" , version = "0.11.0"}
+hash-db = { path = "../hash-db" , version = "0.12.0"}
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.11.0" }
-trie-root = { path = "../trie-root", version = "0.11.0"}
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }
+memory-db = { path = "../memory-db", version = "0.12.0" }
+trie-root = { path = "../trie-root", version = "0.12.0"}
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.0" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.0" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.11.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.12.0" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -121,14 +121,14 @@ where
 
 #[cfg(test)]
 mod test {
-	use memory_db::MemoryDB;
+	use memory_db::{MemoryDB, HashKey};
 	use DBValue;
 	use keccak_hasher::KeccakHasher;
 	use reference_trie::{RefFatDBMut, RefFatDB, Trie, TrieMut};
 
 	#[test]
 	fn fatdb_to_trie() {
-		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefFatDBMut::new(&mut memdb, &mut root);

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -113,7 +113,7 @@ where
 			.map(|res| {
 				res.map(|(hash, value)| {
 					let aux_hash = H::hash(&hash);
-					(self.trie.db().get(&aux_hash).expect("Missing fatdb hash").into_vec(), value)
+					(self.trie.db().get(&aux_hash, &[]).expect("Missing fatdb hash").into_vec(), value)
 				})
 			})
 	}

--- a/trie-db/src/fatdbmut.rs
+++ b/trie-db/src/fatdbmut.rs
@@ -107,14 +107,14 @@ where
 #[cfg(test)]
 mod test {
 	use DBValue;
-	use memory_db::MemoryDB;
+	use memory_db::{MemoryDB, HashKey};
 	use hash_db::Hasher;
 	use keccak_hasher::KeccakHasher;
 	use reference_trie::{RefFatDBMut, RefTrieDB, Trie, TrieMut};
 
 	#[test]
 	fn fatdbmut_to_trie() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, _>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefFatDBMut::new(&mut memdb, &mut root);
@@ -126,7 +126,7 @@ mod test {
 
 	#[test]
 	fn fatdbmut_insert_remove_key_mapping() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, _>::default();
 		let mut root = Default::default();
 		let key = [0x01u8, 0x23];
 		let val = [0x01u8, 0x24];

--- a/trie-db/src/fatdbmut.rs
+++ b/trie-db/src/fatdbmut.rs
@@ -85,7 +85,7 @@ where
 		// insert if it doesn't exist.
 		if out.is_none() {
 			let aux_hash = H::hash(hash.as_ref());
-			db.emplace(aux_hash, DBValue::from_slice(key));
+			db.emplace(aux_hash, &[], DBValue::from_slice(key));
 		}
 		Ok(out)
 	}
@@ -97,7 +97,7 @@ where
 		// remove if it already exists.
 		if out.is_some() {
 			let aux_hash = H::hash(hash.as_ref());
-			self.raw.db_mut().remove(&aux_hash);
+			self.raw.db_mut().remove(&aux_hash, &[]);
 		}
 
 		Ok(out)
@@ -135,8 +135,8 @@ mod test {
 		let mut t = RefFatDBMut::new(&mut memdb, &mut root);
 		t.insert(&key, &val).unwrap();
 		assert_eq!(t.get(&key), Ok(Some(DBValue::from_slice(&val))));
-		assert_eq!(t.db().get(&aux_hash), Some(DBValue::from_slice(&key)));
+		assert_eq!(t.db().get(&aux_hash, &[]), Some(DBValue::from_slice(&key)));
 		t.remove(&key).unwrap();
-		assert_eq!(t.db().get(&aux_hash), None);
+		assert_eq!(t.db().get(&aux_hash, &[]), None);
 	}
 }

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -40,12 +40,14 @@ where
 {
 	/// Look up the given key. If the value is found, it will be passed to the given
 	/// function to decode or copy.
-	pub fn look_up(mut self, mut key: NibbleSlice) -> Result<Option<Q::Item>, H::Out, C::Error> {
+	pub fn look_up(mut self, key: NibbleSlice) -> Result<Option<Q::Item>, H::Out, C::Error> {
+		let mut partial = key;
 		let mut hash = self.hash;
+		let mut key_nibbles = 0;
 
 		// this loop iterates through non-inline nodes.
 		for depth in 0.. {
-			let node_data = match self.db.get(&hash) {
+			let node_data = match self.db.get(&hash, &key.encoded_leftmost(key_nibbles, false)) {
 				Some(value) => value,
 				None => return Err(Box::new(match depth {
 					0 => TrieError::InvalidStateRoot(hash),
@@ -67,25 +69,27 @@ where
 				};
 				match decoded {
 					Node::Leaf(slice, value) => {
-						return Ok(match slice == key {
+						return Ok(match slice == partial {
 							true => Some(self.query.decode(value)),
 							false => None,
 						})
 					}
 					Node::Extension(slice, item) => {
-						if key.starts_with(&slice) {
+						if partial.starts_with(&slice) {
 							node_data = item;
-							key = key.mid(slice.len());
+							partial = partial.mid(slice.len());
+							key_nibbles += slice.len();
 						} else {
 							return Ok(None)
 						}
 					}
-					Node::Branch(children, value) => match key.is_empty() {
+					Node::Branch(children, value) => match partial.is_empty() {
 						true => return Ok(value.map(move |val| self.query.decode(val))),
-						false => match children[key.at(0) as usize] {
+						false => match children[partial.at(0) as usize] {
 							Some(x) => {
 								node_data = x;
-								key = key.mid(1);
+								partial = partial.mid(1);
+								key_nibbles += 1;
 							}
 							None => return Ok(None)
 						}

--- a/trie-db/src/recorder.rs
+++ b/trie-db/src/recorder.rs
@@ -74,7 +74,7 @@ impl<HO: Copy> Recorder<HO> {
 
 #[cfg(test)]
 mod tests {
-	use memory_db::MemoryDB;
+	use memory_db::{MemoryDB, HashKey};
 	use hash_db::Hasher;
 	use keccak_hasher::KeccakHasher;
 	use reference_trie::{RefTrieDB, RefTrieDBMut, Trie, TrieMut, Recorder, Record};
@@ -131,7 +131,7 @@ mod tests {
 
 	#[test]
 	fn trie_record() {
-		let mut db = MemoryDB::default();
+		let mut db = MemoryDB::<KeccakHasher, HashKey<_>, _>::default();
 		let mut root = Default::default();
 		{
 			let mut x = RefTrieDBMut::new(&mut db, &mut root);

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -77,7 +77,7 @@ where
 
 #[cfg(test)]
 mod test {
-	use memory_db::MemoryDB;
+	use memory_db::{MemoryDB, HashKey};
 	use hash_db::Hasher;
 	use keccak_hasher::KeccakHasher;
 	use reference_trie::{RefTrieDBMut, RefSecTrieDB, Trie, TrieMut};
@@ -85,7 +85,7 @@ mod test {
 
 	#[test]
 	fn trie_to_sectrie() {
-		let mut db = MemoryDB::default();
+		let mut db = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefTrieDBMut::new(&mut db, &mut root);

--- a/trie-db/src/sectriedbmut.rs
+++ b/trie-db/src/sectriedbmut.rs
@@ -87,7 +87,7 @@ where
 
 #[cfg(test)]
 mod test {
-	use memory_db::MemoryDB;
+	use memory_db::{MemoryDB, HashKey};
 	use hash_db::Hasher;
 	use keccak_hasher::KeccakHasher;
 	use reference_trie::{RefTrieDB, RefSecTrieDBMut, Trie, TrieMut};
@@ -95,7 +95,7 @@ mod test {
 
 	#[test]
 	fn sectrie_to_trie() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefSecTrieDBMut::new(&mut memdb, &mut root);

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -45,7 +45,7 @@ use elastic_array::ElasticArray36;
 /// use memory_db::*;
 ///
 /// fn main() {
-///   let mut memdb = MemoryDB::default();
+///   let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, _>::default();
 ///   let mut root = Default::default();
 ///   RefTrieDBMut::new(&mut memdb, &mut root).insert(b"foo", b"bar").unwrap();
 ///   let t = RefTrieDB::new(&memdb, &root).unwrap();
@@ -459,7 +459,7 @@ impl<'a, H: Hasher, C: NodeCodec<H>> Iterator for TrieDBIterator<'a, H, C> {
 
 #[cfg(test)]
 mod tests {
-	use memory_db::MemoryDB;
+	use memory_db::{MemoryDB, HashKey};
 	use keccak_hasher::KeccakHasher;
 	use DBValue;
 	use reference_trie::{RefTrieDB, RefTrieDBMut, RefLookup, Trie, TrieMut, NibbleSlice};
@@ -471,7 +471,7 @@ mod tests {
 			(hex!("0103000000000000000469").to_vec(), hex!("ffffffffff").to_vec()),
 		];
 
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
@@ -499,7 +499,7 @@ mod tests {
 			(hex!("0103000000000000000469").to_vec(), hex!("ffffffffff").to_vec()),
 		];
 
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
@@ -523,7 +523,7 @@ mod tests {
 	fn iterator() {
 		let d = vec![DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B")];
 
-		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
@@ -541,7 +541,7 @@ mod tests {
 	fn iterator_seek() {
 		let d = vec![ DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B") ];
 
-		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
@@ -580,7 +580,7 @@ mod tests {
 
 	#[test]
 	fn get_len() {
-		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
@@ -598,7 +598,7 @@ mod tests {
 	fn debug_output_supports_pretty_print() {
 		let d = vec![ DBValue::from_slice(b"A"), DBValue::from_slice(b"AA"), DBValue::from_slice(b"AB"), DBValue::from_slice(b"B") ];
 
-		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let root = {
 			let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
@@ -666,7 +666,7 @@ mod tests {
 	fn test_lookup_with_corrupt_data_returns_decoder_error() {
 		use std::marker::PhantomData;
 
-		let mut memdb = MemoryDB::<KeccakHasher, DBValue>::default();
+		let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefTrieDBMut::new(&mut memdb, &mut root);

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -269,7 +269,7 @@ impl<'a, H> Index<&'a StorageHandle> for NodeStorage<H> {
 /// use memory_db::*;
 ///
 /// fn main() {
-///   let mut memdb = MemoryDB::default();
+///   let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, DBValue>::default();
 ///   let mut root = Default::default();
 ///   let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 ///   assert!(t.is_empty());
@@ -988,7 +988,7 @@ mod tests {
 	use env_logger;
 	use standardmap::*;
 	use DBValue;
-	use memory_db::MemoryDB;
+	use memory_db::{MemoryDB, PrefixedKey};
 	use hash_db::{Hasher, HashDB};
 	use keccak_hasher::KeccakHasher;
 	use reference_trie::{RefTrieDBMut, TrieMut, NodeCodec,
@@ -1032,7 +1032,7 @@ mod tests {
 			}.make_with(&mut seed);
 
 			let real = ref_trie_root(x.clone());
-			let mut memdb = MemoryDB::default();
+			let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 			let mut root = Default::default();
 			let mut memtrie = populate_trie(&mut memdb, &mut root, &x);
 
@@ -1062,7 +1062,7 @@ mod tests {
 
 	#[test]
 	fn init() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		assert_eq!(*t.root(), ReferenceNodeCodec::hashed_null_node());
@@ -1070,7 +1070,7 @@ mod tests {
 
 	#[test]
 	fn insert_on_empty() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
@@ -1081,12 +1081,12 @@ mod tests {
 	fn remove_to_empty() {
 		let big_value = b"00000000000000000000000000000000";
 
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t1 = RefTrieDBMut::new(&mut memdb, &mut root);
 		t1.insert(&[0x01, 0x23], big_value).unwrap();
 		t1.insert(&[0x01, 0x34], big_value).unwrap();
-		let mut memdb2 = MemoryDB::default();
+		let mut memdb2 = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root2 = Default::default();
 		let mut t2 = RefTrieDBMut::new(&mut memdb2, &mut root2);
 
@@ -1098,7 +1098,7 @@ mod tests {
 
 	#[test]
 	fn insert_replace_root() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
@@ -1108,7 +1108,7 @@ mod tests {
 
 	#[test]
 	fn insert_make_branch_root() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
@@ -1121,7 +1121,7 @@ mod tests {
 
 	#[test]
 	fn insert_into_branch_root() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
@@ -1136,7 +1136,7 @@ mod tests {
 
 	#[test]
 	fn insert_value_into_branch_root() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
@@ -1149,7 +1149,7 @@ mod tests {
 
 	#[test]
 	fn insert_split_leaf() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
@@ -1162,7 +1162,7 @@ mod tests {
 
 	#[test]
 	fn insert_split_extenstion() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01, 0x23, 0x45], &[0x01]).unwrap();
@@ -1180,7 +1180,7 @@ mod tests {
 		let big_value0 = b"00000000000000000000000000000000";
 		let big_value1 = b"11111111111111111111111111111111";
 
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], big_value0).unwrap();
@@ -1195,7 +1195,7 @@ mod tests {
 	fn insert_duplicate_value() {
 		let big_value = b"00000000000000000000000000000000";
 
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], big_value).unwrap();
@@ -1208,7 +1208,7 @@ mod tests {
 
 	#[test]
 	fn test_at_empty() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let t = RefTrieDBMut::new(&mut memdb, &mut root);
 		assert_eq!(t.get(&[0x5]).unwrap(), None);
@@ -1216,7 +1216,7 @@ mod tests {
 
 	#[test]
 	fn test_at_one() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
@@ -1227,7 +1227,7 @@ mod tests {
 
 	#[test]
 	fn test_at_three() {
-		let mut memdb = MemoryDB::default();
+		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
@@ -1257,12 +1257,12 @@ mod tests {
 			}.make_with(&mut seed);
 
 			let real = ref_trie_root(x.clone());
-			let mut memdb = MemoryDB::default();
+			let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 			let mut root = Default::default();
 			let mut memtrie = populate_trie(&mut memdb, &mut root, &x);
 			let mut y = x.clone();
 			y.sort_by(|ref a, ref b| a.0.cmp(&b.0));
-			let mut memdb2 = MemoryDB::default();
+			let mut memdb2 = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 			let mut root2 = Default::default();
 			let mut memtrie_sorted = populate_trie(&mut memdb2, &mut root2, &y);
 			if *memtrie.root() != real || *memtrie_sorted.root() != real {
@@ -1284,7 +1284,7 @@ mod tests {
 
 	#[test]
 	fn test_trie_existing() {
-		let mut db = MemoryDB::default();
+		let mut db = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		{
 			let mut t = RefTrieDBMut::new(&mut db, &mut root);
@@ -1307,7 +1307,7 @@ mod tests {
 				count: 4,
 		}.make_with(&mut seed);
 
-		let mut db = MemoryDB::default();
+		let mut db = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut db, &mut root);
 		for &(ref key, ref value) in &x {
@@ -1335,7 +1335,7 @@ mod tests {
 				count: 4,
 		}.make_with(&mut seed);
 
-		let mut db = MemoryDB::default();
+		let mut db = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
 		let mut root = Default::default();
 		let mut t = RefTrieDBMut::new(&mut db, &mut root);
 		for &(ref key, ref value) in &x {

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 categories = [ "no-std" ]
 
 [dependencies]
-hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
+hash-db = { path = "../hash-db", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.1"
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
+keccak-hasher = { path = "../test-support/keccak-hasher" }
+trie-standardmap = { path = "../test-support/trie-standardmap" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.11.0" }
+reference-trie = { path = "../test-support/reference-trie" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
For some applications, such as substrate it is desirable to have each node to be unique in the trie. So that the same node can't be inserted into two separate branches of the same trie. This simplifies implementation of node storage quite a lot, since it removes the need for reference counting.

In ethereum the uniqueness is already guaranteed by the fact that the keys are hashes and each value ends up in a leaf node with a long random partial key. In Substrate this is not the case, as the keys are plain.

This PR introduces an additional parameter for `HashDB` functions that takes encoded partial node key. This allows for separating colliding nodes on the database levels, and for more efficient database implementation. E.g. The nodes that are close to each other in the trie may be grouped on disk.
Trie root calculation is not affected.