### PR TITLE
No std support for trie

### DIFF
--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "hash-db"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2"
 categories = [ "no-std" ]
 
+[dependencies]
+hashbrown = { version = "0.1" }
+
 [features]
 default = ["std"]
-std = []
+std = [
+]

--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-db"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2.0"

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 //! Database of byte-slices keyed to their hash.
-
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
+
+#[cfg(not(feature = "std"))]
+extern crate hashbrown;
 
 #[cfg(feature = "std")]
 use std::fmt::Debug;
@@ -30,6 +32,8 @@ impl<T: Debug> DebugIfStd for T {}
 
 #[cfg(not(feature = "std"))]
 use core::hash;
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
 #[cfg(not(feature = "std"))]
 pub trait DebugIfStd {}
 #[cfg(not(feature = "std"))]
@@ -51,7 +55,6 @@ pub trait Hasher: Sync + Send {
 }
 
 /// Trait modelling datastore keyed by a hash defined by the `Hasher`.
-#[cfg(feature = "std")]
 pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 	/// Get the keys in the database together with number of underlying references.
 	fn keys(&self) -> HashMap<H::Out, i32>;
@@ -77,7 +80,6 @@ pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 }
 
 /// Upcast trait.
-#[cfg(feature = "std")]
 pub trait AsHashDB<H: Hasher, T> {
 	/// Perform upcast to HashDB for anything that derives from HashDB.
 	fn as_hash_db(&self) -> &HashDB<H, T>;
@@ -87,9 +89,7 @@ pub trait AsHashDB<H: Hasher, T> {
 
 // NOTE: There used to be a `impl<T> AsHashDB for T` but that does not work with generics. See https://stackoverflow.com/questions/48432842/implementing-a-trait-for-reference-and-non-reference-types-causes-conflicting-im
 // This means we need concrete impls of AsHashDB in several places, which somewhat defeats the point of the trait.
-#[cfg(feature = "std")]
 impl<'a, H: Hasher, T> AsHashDB<H, T> for &'a mut HashDB<H, T> {
 	fn as_hash_db(&self) -> &HashDB<H, T> { &**self }
 	fn as_hash_db_mut<'b>(&'b mut self) -> &'b mut (HashDB<H, T> + 'b) { &mut **self }
 }
-

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -50,7 +50,6 @@ pub trait Hasher: Sync + Send {
 /// Trait modelling a plain datastore whose key is a fixed type.
 /// The caller should ensure that a key only corresponds to
 /// one value.
-#[cfg(feature = "std")]
 pub trait PlainDB<K, V>: Send + Sync + AsPlainDB<K, V> {
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
@@ -72,7 +71,6 @@ pub trait PlainDB<K, V>: Send + Sync + AsPlainDB<K, V> {
 }
 
 /// Trait for immutable reference of PlainDB.
-#[cfg(feature = "std")]
 pub trait PlainDBRef<K, V> {
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
@@ -82,13 +80,11 @@ pub trait PlainDBRef<K, V> {
 	fn contains(&self, key: &K) -> bool;
 }
 
-#[cfg(feature = "std")]
 impl<'a, K, V> PlainDBRef<K, V> for &'a PlainDB<K, V> {
 	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
 	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
 }
 
-#[cfg(feature = "std")]
 impl<'a, K, V> PlainDBRef<K, V> for &'a mut PlainDB<K, V> {
 	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
 	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
@@ -117,7 +113,6 @@ pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 }
 
 /// Trait for immutable reference of HashDB.
-#[cfg(feature = "std")]
 pub trait HashDBRef<H: Hasher, T> {
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
@@ -127,20 +122,17 @@ pub trait HashDBRef<H: Hasher, T> {
 	fn contains(&self, key: &H::Out) -> bool;
 }
 
-#[cfg(feature = "std")]
 impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a HashDB<H, T> {
 	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
 	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
 }
 
-#[cfg(feature = "std")]
 impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut HashDB<H, T> {
 	fn get(&self, key: &H::Out) -> Option<T> { HashDB::get(*self, key) }
 	fn contains(&self, key: &H::Out) -> bool { HashDB::contains(*self, key) }
 }
 
 /// Upcast trait for HashDB.
-#[cfg(feature = "std")]
 pub trait AsHashDB<H: Hasher, T> {
 	/// Perform upcast to HashDB for anything that derives from HashDB.
 	fn as_hash_db(&self) -> &HashDB<H, T>;
@@ -149,7 +141,6 @@ pub trait AsHashDB<H: Hasher, T> {
 }
 
 /// Upcast trait for PlainDB.
-#[cfg(feature = "std")]
 pub trait AsPlainDB<K, V> {
 	/// Perform upcast to PlainDB for anything that derives from PlainDB.
 	fn as_plain_db(&self) -> &PlainDB<K, V>;

--- a/hash256-std-hasher/Cargo.toml
+++ b/hash256-std-hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash256-std-hasher"
 description = "Standard library hasher for 256-bit prehashed keys."
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 homepage = "https://github.com/paritytech/trie"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -7,9 +7,10 @@ repository = "https://github.com/paritytech/parity-common"
 license = "Apache-2.0"
 
 [dependencies]
-heapsize = "0.4"
+heapsize = { version = "0.4", optional = true}
 hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
-hashbrown = "0.1"
+#hashmap_core = "0.1"
+hashbrown = { version = "0.1", features = [ "nightly" ] }
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0"}
@@ -18,9 +19,9 @@ criterion = "0.2.8"
 [features]
 default = ["std"]
 std = [
+  "heapsize",
   "hash-db/std",
 ]
-
 [[bench]]
 name = "bench"
 harness = false

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -9,8 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 heapsize = { version = "0.4", optional = true}
 hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
-#hashmap_core = "0.1"
-hashbrown = { version = "0.1", features = [ "nightly" ] }
+hashbrown = { version = "0.1" }
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0"}
@@ -22,6 +21,8 @@ std = [
   "heapsize",
   "hash-db/std",
 ]
+nightly = ["hashbrown/nightly"]
+
 [[bench]]
 name = "bench"
 harness = false

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 heapsize = { version = "0.4", optional = true}
 hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
-hashbrown = { version = "0.1" }
+hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0"}
@@ -20,8 +20,8 @@ default = ["std"]
 std = [
   "heapsize",
   "hash-db/std",
+  "hashmap_core/disable",
 ]
-nightly = ["hashbrown/nightly"]
 
 [[bench]]
 name = "bench"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,11 +8,18 @@ license = "Apache-2"
 
 [dependencies]
 heapsize = "0.4"
-hash-db = { path = "../hash-db" }
+hash-db = { path = "../hash-db", default-features = false }
+hashbrown = "0.1"
 
 [dev-dependencies]
-keccak-hasher = { path = "../test-support/keccak-hasher" }
+keccak-hasher = { path = "../test-support/keccak-hasher", default-features = false }
 criterion = "0.1.2"
+
+[features]
+default = ["std"]
+std = [
+  "hash-db/std",
+]
 
 [[bench]]
 name = "bench"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,11 +8,11 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true}
-hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.11.1"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0"}
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.1"}
 criterion = "0.2.8"
 
 [features]

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -35,6 +35,9 @@ use std::{
 	collections::HashMap,
 	hash,
 	mem,
+	marker::PhantomData,
+	cmp::Eq,
+	borrow::Borrow,
 };
 
 #[cfg(not(feature = "std"))]
@@ -47,7 +50,13 @@ use hashmap_core::{
 use core::{
 	hash,
 	mem,
+	marker::PhantomData,
+	cmp::Eq,
+	borrow::Borrow,
 };
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// Reference-counted memory-based `HashDB` implementation.
 ///
@@ -105,11 +114,11 @@ pub struct MemoryDB<H, KF, T>
 	data: HashMap<KF::Key, (T, i32)>,
 	hashed_null_node: H::Out,
 	null_node_data: T,
-	_kf: ::std::marker::PhantomData<KF>,
+	_kf: PhantomData<KF>,
 }
 
 pub trait KeyFunction<H: KeyHasher> {
-	type Key: Send + Sync + Clone + std::hash::Hash + std::cmp::Eq ;
+	type Key: Send + Sync + Clone + hash::Hash + Eq ;
 
 	fn key(hash: &H::Out, prefix: &[u8]) -> Self::Key;
 }
@@ -129,7 +138,7 @@ pub fn hash_key<H: KeyHasher>(key: &H::Out, _prefix: &[u8]) -> H::Out {
 }
 
 /// Key function that only uses the hash
-pub struct HashKey<H: KeyHasher>(std::marker::PhantomData<H>);
+pub struct HashKey<H: KeyHasher>(PhantomData<H>);
 
 impl<H: KeyHasher> KeyFunction<H> for HashKey<H> {
 	type Key = H::Out;
@@ -140,7 +149,7 @@ impl<H: KeyHasher> KeyFunction<H> for HashKey<H> {
 }
 
 /// Key function that concatenates prefix and hash.
-pub struct PrefixedKey<H: KeyHasher>(std::marker::PhantomData<H>);
+pub struct PrefixedKey<H: KeyHasher>(PhantomData<H>);
 
 impl<H: KeyHasher> KeyFunction<H> for PrefixedKey<H> {
 	type Key = Vec<u8>;
@@ -288,12 +297,8 @@ where
 	}
 }
 
-<<<<<<< HEAD
 #[cfg(feature = "std")]
-impl<H, T> MemoryDB<H, T>
-=======
 impl<H, KF, T> MemoryDB<H, KF, T>
->>>>>>> master
 where
 	H: KeyHasher,
 	T: HeapSizeOf,
@@ -311,7 +316,7 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 	KF: Send + Sync + KeyFunction<H>,
-	KF::Key: std::borrow::Borrow<[u8]> + for <'a> From<&'a [u8]>,
+	KF::Key: Borrow<[u8]> + for <'a> From<&'a [u8]>,
 {
 	fn get(&self, key: &H::Out) -> Option<T> {
 		match self.data.get(key.as_ref()) {
@@ -360,7 +365,7 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 	KF: Send + Sync + KeyFunction<H>,
-	KF::Key: std::borrow::Borrow<[u8]> + for <'a> From<&'a [u8]>,
+	KF::Key: Borrow<[u8]> + for <'a> From<&'a [u8]>,
 {
 	fn get(&self, key: &H::Out) -> Option<T> { PlainDB::get(self, key) }
 	fn contains(&self, key: &H::Out) -> bool { PlainDB::contains(self, key) }
@@ -459,7 +464,7 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + for<'a> From<&'a[u8]> + Clone + Send + Sync,
 	KF: Send + Sync + KeyFunction<H>,
-	KF::Key: std::borrow::Borrow<[u8]> + for <'a> From<&'a [u8]>,
+	KF::Key: Borrow<[u8]> + for <'a> From<&'a [u8]>,
 {
 	fn as_plain_db(&self) -> &PlainDB<H::Out, T> { self }
 	fn as_plain_db_mut(&mut self) -> &mut PlainDB<H::Out, T> { self }
@@ -479,9 +484,6 @@ where
 mod tests {
 	use super::{MemoryDB, HashDB, KeyHasher, HashKey};
 	use keccak_hasher::KeccakHasher;
-
-	#[cfg(not(feature = "std"))]
-	use alloc::vec::Vec;
 
 	#[test]
 	fn memorydb_remove_and_purge() {

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -14,16 +14,39 @@
 
 //! Reference-counted memory-based `HashDB` implementation.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
 extern crate hash_db;
 extern crate heapsize;
+#[cfg(not(feature = "std"))]
+extern crate hashbrown;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 #[cfg(test)] extern crate keccak_hasher;
-
 use hash_db::{HashDB, Hasher as KeyHasher, AsHashDB};
+
 use heapsize::HeapSizeOf;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::hash;
-use std::mem;
+#[cfg(feature = "std")]
+use std::{
+	collections::hash_map::Entry,
+	collections::HashMap,
+	hash,
+	mem,
+};
+
+#[cfg(not(feature = "std"))]
+use hashbrown::{
+	HashMap,
+	hash_map::Entry,
+};
+
+
+#[cfg(not(feature = "std"))]
+use core::{
+	hash,
+	mem,
+};
 
 // Backing `HashMap` parametrized with a `Hasher` for the keys `Hasher::Out` and the `Hasher::StdHasher`
 // as hash map builder.
@@ -325,6 +348,9 @@ where
 mod tests {
 	use super::*;
 	use keccak_hasher::KeccakHasher;
+
+	#[cfg(not(feature = "std"))]
+	use alloc::vec::Vec;
 
 	#[test]
 	fn memorydb_remove_and_purge() {

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -21,7 +21,7 @@ extern crate hash_db;
 #[cfg(feature = "std")]
 extern crate heapsize;
 #[cfg(not(feature = "std"))]
-extern crate hashbrown;
+extern crate hashmap_core;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(test)] extern crate keccak_hasher;
@@ -38,9 +38,9 @@ use std::{
 };
 
 #[cfg(not(feature = "std"))]
-use hashbrown::{
+use hashmap_core::{
 	HashMap,
-	hash_map::Entry,
+	map::Entry,
 };
 
 #[cfg(not(feature = "std"))]

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -18,14 +18,17 @@
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
 extern crate hash_db;
+#[cfg(feature = "std")]
 extern crate heapsize;
 #[cfg(not(feature = "std"))]
 extern crate hashbrown;
+//extern crate hashmap_core;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(test)] extern crate keccak_hasher;
 
 use hash_db::{HashDB, HashDBRef, PlainDB, PlainDBRef, Hasher as KeyHasher, AsHashDB, AsPlainDB};
+#[cfg(feature = "std")]
 use heapsize::HeapSizeOf;
 #[cfg(feature = "std")]
 use std::{
@@ -40,6 +43,13 @@ use hashbrown::{
 	HashMap,
 	hash_map::Entry,
 };
+/*
+#[cfg(not(feature = "std"))]
+use hashmap_core::{
+	HashMap,
+	map::Entry,
+};
+*/
 
 
 #[cfg(not(feature = "std"))]
@@ -239,6 +249,7 @@ impl<'a, H: KeyHasher, T> MemoryDB<H, T> where T: From<&'a [u8]> {
 	}
 }
 
+#[cfg(feature = "std")]
 impl<H, T> MemoryDB<H, T>
 where
 	H: KeyHasher,

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -22,7 +22,6 @@ extern crate hash_db;
 extern crate heapsize;
 #[cfg(not(feature = "std"))]
 extern crate hashbrown;
-//extern crate hashmap_core;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(test)] extern crate keccak_hasher;
@@ -43,14 +42,6 @@ use hashbrown::{
 	HashMap,
 	hash_map::Entry,
 };
-/*
-#[cfg(not(feature = "std"))]
-use hashmap_core::{
-	HashMap,
-	map::Entry,
-};
-*/
-
 
 #[cfg(not(feature = "std"))]
 use core::{

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -8,5 +8,12 @@ license = "Apache-2"
 
 [dependencies]
 tiny-keccak = "1.4.2"
-hash-db = { path = "../../hash-db" }
+hash-db = { path = "../../hash-db", default-features = false }
 hash256-std-hasher = { path = "../../hash256-std-hasher" }
+
+[features]
+default = ["std"]
+# no actual support for std, only to avoid a cargo issues
+std = [
+  "hash-db/std",
+]

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 tiny-keccak = "1.4.2"
-hash-db = { path = "../../hash-db", default-features = false, version = "0.11.0" }
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.11.0" }
+hash-db = { path = "../../hash-db", default-features = false, version = "0.11.1" }
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.11.1" }
 
 [features]
 default = ["std"]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -10,8 +10,8 @@ license = "Apache-2"
 hash-db = { path = "../../hash-db" }
 hash256-std-hasher = { path = "../../hash256-std-hasher" }
 keccak-hasher = { path = "../keccak-hasher" }
-trie-db = { path = "../../trie-db" }
-trie-root = { path = "../../trie-root" }
+trie-db = { path = "../../trie-db", default-features = false }
+trie-root = { path = "../../trie-root", default-features = false }
 parity-codec = { version = "2.1" }
 parity-codec-derive = { version = "2.1" }
 
@@ -22,3 +22,10 @@ criterion = "0.1.2"
 [[bench]]
 name = "bench"
 harness = false
+
+[features]
+default = ["std"]
+# no actual support for std, only to avoid a cargo issues
+std = [
+  "trie-db/std",
+]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "reference-trie"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.11.0"}
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.11.0" }
-keccak-hasher = { path = "../keccak-hasher", version = "0.11.0" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.11.0"}
-trie-root = { path = "../../trie-root", default-features = false, version = "0.11.0" }
+hash-db = { path = "../../hash-db" , version = "0.11.1"}
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.11.1" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.11.1" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.11.1"}
+trie-root = { path = "../../trie-root", default-features = false, version = "0.11.1" }
 parity-codec = "3.0"
 parity-codec-derive = "3.0"
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.11.0" }
+trie-bench = { path = "../trie-bench", version = "0.11.1" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.11.0" }
-trie-standardmap = { path = "../trie-standardmap", version  = "0.11.0" }
-hash-db = { path = "../../hash-db" , version = "0.11.0"}
-memory-db = { path = "../../memory-db", version = "0.11.0" }
-trie-root = { path = "../../trie-root", version = "0.11.0" }
-trie-db = { path = "../../trie-db", version = "0.11.0" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.11.1" }
+trie-standardmap = { path = "../trie-standardmap", version  = "0.11.1" }
+hash-db = { path = "../../hash-db" , version = "0.11.1"}
+memory-db = { path = "../../memory-db", version = "0.11.1" }
+trie-root = { path = "../../trie-root", version = "0.11.1" }
+trie-db = { path = "../../trie-db", version = "0.11.1" }
 criterion = "0.2.8"
 parity-codec = "3.0"

--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "trie-standardmap"
 description = "Standard test map for profiling tries"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.11.0"}
-hash-db = { path = "../../hash-db" , version = "0.11.0"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.11.1"}
+hash-db = { path = "../../hash-db" , version = "0.11.1"}
 criterion = "0.2.8"

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 log = "0.4"
 rand = { version = "0.6", default-features = false }
-elastic-array = { version = "0.10.1", default-features = false }
+elastic-array = { version = "0.10.2", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
 hashmap_core = { version = "0.1" }
 

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/parity-common"
@@ -10,17 +10,17 @@ license = "Apache-2.0"
 log = "0.4"
 rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10.2", default-features = false }
-hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.11.1"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.11.0" }
-trie-root = { path = "../trie-root", version = "0.11.0"}
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }
+memory-db = { path = "../memory-db", version = "0.11.1" }
+trie-root = { path = "../trie-root", version = "0.11.1"}
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.1" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.1" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.11.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.11.1" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -11,8 +11,7 @@ log = "0.4"
 rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10.1", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
-#hashmap_core = "0.1"
-hashbrown = { version = "0.1", features = [ "nightly" ] }
+hashbrown = { version = "0.1" }
 
 [dev-dependencies]
 env_logger = "0.6"
@@ -32,7 +31,7 @@ std = [
   "hash-db/std",
   "rand/std",
 ]
-
+nightly = ["hashbrown/nightly"]
 [[bench]]
 name = "bench"
 harness = false

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/parity-common"
@@ -9,8 +9,10 @@ license = "Apache-2"
 [dependencies]
 log = { version = "0.3" }
 rand = { version = "0.4" }
-elastic-array = { version = "0.10" }
-hash-db = { path = "../hash-db" }
+#elastic-array = { version = "0.10" }
+elastic-array = { version = "0.10", path = "../../elastic-array", default-features = false }
+hash-db = { path = "../hash-db", default-features = false }
+hashbrown = { version = "0.1" }
 
 [dev-dependencies]
 env_logger = "0.5"
@@ -18,9 +20,16 @@ memory-db = { path = "../memory-db" }
 trie-root = { path = "../trie-root" }
 trie-standardmap = { path = "../test-support/trie-standardmap" }
 keccak-hasher = { path = "../test-support/keccak-hasher" }
-reference-trie = { path = "../test-support/reference-trie" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false }
 hex-literal = "0.1"
 criterion = "0.1.2"
+
+[features]
+default = ["std"]
+std = [
+  "elastic-array/std",
+  "hash-db/std",
+]
 
 [[bench]]
 name = "bench"

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -8,10 +8,11 @@ license = "Apache-2.0"
 
 [dependencies]
 log = "0.4"
-rand = "0.6"
+rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10.1", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
-hashbrown = { version = "0.1" }
+#hashmap_core = "0.1"
+hashbrown = { version = "0.1", features = [ "nightly" ] }
 
 [dev-dependencies]
 env_logger = "0.6"
@@ -20,7 +21,7 @@ trie-root = { path = "../trie-root", version = "0.11.0"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.11.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.11.0" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 
@@ -29,7 +30,7 @@ default = ["std"]
 std = [
   "elastic-array/std",
   "hash-db/std",
-  "reference-trie/std",
+  "rand/std",
 ]
 
 [[bench]]

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4"
 rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10.1", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
-hashbrown = { version = "0.1" }
+hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
 env_logger = "0.6"
@@ -30,8 +30,9 @@ std = [
   "elastic-array/std",
   "hash-db/std",
   "rand/std",
+  "hashmap_core/disable",
 ]
-nightly = ["hashbrown/nightly"]
+
 [[bench]]
 name = "bench"
 harness = false

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -16,6 +16,9 @@ use hash_db::{HashDB, Hasher};
 use super::{Result, DBValue, TrieDB, Trie, TrieDBIterator, TrieItem, TrieIterator, Query};
 use node_codec::NodeCodec;
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 /// A `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
 /// Additionaly it stores inserted hash-key mappings for later retrieval.
 ///

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -41,6 +41,7 @@ extern crate memory_db;
 extern crate keccak_hasher;
 #[cfg(all(feature = "std", test))]
 extern crate reference_trie;
+
 #[cfg(not(feature = "std"))]
 extern crate hashbrown;
 
@@ -59,6 +60,20 @@ use core_::{fmt, marker::PhantomData};
 
 #[cfg(feature = "std")]
 use std::error::Error;
+
+#[cfg(feature = "std")]
+use std::fmt::Debug;
+#[cfg(feature = "std")]
+pub trait DebugIfStd: Debug {}
+#[cfg(feature = "std")]
+impl<T: Debug> DebugIfStd for T {}
+
+
+#[cfg(not(feature = "std"))]
+pub trait DebugIfStd {}
+#[cfg(not(feature = "std"))]
+impl<T> DebugIfStd for T {}
+
 
 pub mod node;
 pub mod triedb;

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
 //! Trie interface and implementation.
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 extern crate elastic_array;
 extern crate hash_db;
 extern crate rand;
@@ -32,11 +39,26 @@ extern crate trie_root;
 extern crate memory_db;
 #[cfg(test)]
 extern crate keccak_hasher;
-#[cfg(test)]
+#[cfg(all(feature = "std", test))]
 extern crate reference_trie;
+#[cfg(not(feature = "std"))]
+extern crate hashbrown;
 
-use std::{fmt, error};
-use std::marker::PhantomData;
+#[cfg(feature = "std")]
+use std as core_;
+#[cfg(not(feature = "std"))]
+use core as core_;
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use core_::{fmt, marker::PhantomData};
+
+#[cfg(feature = "std")]
+use std::error::Error;
 
 pub mod node;
 pub mod triedb;
@@ -80,7 +102,7 @@ pub enum TrieError<T, E> {
 	DecoderError(T, E),
 }
 
-impl<T, E> fmt::Display for TrieError<T, E> where T: std::fmt::Debug, E: std::fmt::Debug {
+impl<T, E> fmt::Display for TrieError<T, E> where T: ::core_::fmt::Debug, E: ::core_::fmt::Debug {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
 			TrieError::InvalidStateRoot(ref root) => write!(f, "Invalid state root: {:?}", root),
@@ -92,7 +114,8 @@ impl<T, E> fmt::Display for TrieError<T, E> where T: std::fmt::Debug, E: std::fm
 	}
 }
 
-impl<T, E> error::Error for TrieError<T, E> where T: std::fmt::Debug, E: std::error::Error {
+#[cfg(feature = "std")]
+impl<T, E> Error for TrieError<T, E> where T: ::core_::fmt::Debug, E: Error {
 	fn description(&self) -> &str {
 		match *self {
 			TrieError::InvalidStateRoot(_) => "Invalid state root",
@@ -103,7 +126,7 @@ impl<T, E> error::Error for TrieError<T, E> where T: std::fmt::Debug, E: std::er
 }
 
 /// Trie result type. Boxed to avoid copying around extra space for the `Hasher`s `Out` on successful queries.
-pub type Result<T, H, E> = ::std::result::Result<T, Box<TrieError<H, E>>>;
+pub type Result<T, H, E> = ::core_::result::Result<T, Box<TrieError<H, E>>>;
 
 
 /// Trie-Item type used for iterators over trie data.

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -43,7 +43,7 @@ extern crate keccak_hasher;
 extern crate reference_trie;
 
 #[cfg(not(feature = "std"))]
-extern crate hashbrown;
+extern crate hashmap_core;
 
 #[cfg(feature = "std")]
 use std as core_;

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -19,7 +19,10 @@ use nibbleslice::NibbleSlice;
 use node::Node;
 use node_codec::NodeCodec;
 use super::{DBValue, Result, TrieError, Query};
-use std::marker::PhantomData;
+use ::core_::marker::PhantomData;
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
 
 /// Trie lookup helper object.
 pub struct Lookup<'a, H: Hasher + 'a, C: NodeCodec<H>, Q: Query<H>> {

--- a/trie-db/src/nibbleslice.rs
+++ b/trie-db/src/nibbleslice.rs
@@ -14,8 +14,8 @@
 
 //! Nibble-orientated view onto byte-slice, allowing nibble-precision offsets.
 
-use std::cmp::*;
-use std::fmt;
+use ::core_::cmp::*;
+use ::core_::fmt;
 use elastic_array::ElasticArray36;
 
 /// Nibble-orientated view onto byte-slice, allowing nibble-precision offsets.

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -17,6 +17,9 @@ use nibbleslice::NibbleSlice;
 use nibblevec::NibbleVec;
 use super::DBValue;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// Partial node key type.
 pub type NodeKey = ElasticArray36<u8>;
 

--- a/trie-db/src/node_codec.rs
+++ b/trie-db/src/node_codec.rs
@@ -26,10 +26,13 @@ use std::error::Error;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use elastic_array::{ElasticArray128};
+use elastic_array::ElasticArray128;
 
 #[cfg(not(feature = "std"))]
-pub trait Error: core::fmt::Debug + core::fmt::Display { }
+pub trait Error: core::fmt::Debug {}
+
+#[cfg(not(feature = "std"))]
+impl<T: core::fmt::Debug> Error for T {}
 
 /// Trait for trie node encoding/decoding
 pub trait NodeCodec<H: Hasher>: Sized {

--- a/trie-db/src/node_codec.rs
+++ b/trie-db/src/node_codec.rs
@@ -19,12 +19,22 @@ use hash_db::Hasher;
 use node::Node;
 use ChildReference;
 
+#[cfg(feature = "std")]
+use std::error::Error;
+
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use elastic_array::{ElasticArray128};
+
+#[cfg(not(feature = "std"))]
+pub trait Error: core::fmt::Debug + core::fmt::Display { }
 
 /// Trait for trie node encoding/decoding
 pub trait NodeCodec<H: Hasher>: Sized {
 	/// Codec error type
-	type Error: ::std::error::Error;
+	type Error: Error;
 
 	/// Get the hashed null node.
 	fn hashed_null_node() -> H::Out;

--- a/trie-db/src/recorder.rs
+++ b/trie-db/src/recorder.rs
@@ -14,6 +14,9 @@
 
 //! Trie query recorder.
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 /// A record of a visited node.
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Record<HO> {
@@ -68,7 +71,7 @@ impl<HO: Copy> Recorder<HO> {
 
 	/// Drain all visited records.
 	pub fn drain(&mut self) -> Vec<Record<HO>> {
-		::std::mem::replace(&mut self.nodes, Vec::new())
+		::core_::mem::replace(&mut self.nodes, Vec::new())
 	}
 }
 

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -17,6 +17,9 @@ use super::triedb::TrieDB;
 use super::{Result, DBValue, Trie, TrieItem, TrieIterator, Query};
 use node_codec::NodeCodec;
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 /// A `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
 ///
 /// Use it as a `Trie` trait object. You can use `raw()` to get the backing `TrieDB` object.

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ::core_::fmt;
 use hash_db::{Hasher, HashDBRef};
 use nibbleslice::NibbleSlice;
 use super::node::{Node, OwnedNode};
@@ -22,9 +21,11 @@ use super::{Result, DBValue, Trie, TrieItem, TrieError, TrieIterator, Query};
 use ::core_::marker::PhantomData;
 
 #[cfg(feature = "std")]
+use ::std::fmt;
+#[cfg(feature = "std")]
 use ::std::borrow::Cow;
 #[cfg(not(feature = "std"))]
-use ::alloc::{borrow::Cow, format};
+use ::alloc::borrow::Cow;
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
@@ -151,6 +152,7 @@ where
 	is_root: bool,
 }
 
+#[cfg(feature="std")]
 impl<'db, 'a, H, C> fmt::Debug for TrieAwareDebugNode<'db, 'a, H, C>
 where
 	H: Hasher,
@@ -207,6 +209,7 @@ where
 	}
 }
 
+#[cfg(feature="std")]
 impl<'db, H, C> fmt::Debug for TrieDB<'db, H, C>
 where
 	H: Hasher,

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -12,15 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
+use ::core_::fmt;
 use hash_db::*;
 use nibbleslice::NibbleSlice;
 use super::node::{Node, OwnedNode};
 use node_codec::NodeCodec;
 use super::lookup::Lookup;
 use super::{Result, DBValue, Trie, TrieItem, TrieError, TrieIterator, Query};
-use std::marker::PhantomData;
-use std::borrow::Cow;
+use ::core_::marker::PhantomData;
+
+#[cfg(feature = "std")]
+use ::std::borrow::Cow;
+#[cfg(not(feature = "std"))]
+use ::alloc::{borrow::Cow, format};
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// A `Trie` implementation using a generic `HashDB` backing database, a `Hasher`
 /// implementation to generate keys and a `NodeCodec` implementation to encode/decode

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -140,6 +140,8 @@ where
 	}
 }
 
+
+#[cfg(feature="std")]
 // This is for pretty debug output only
 struct TrieAwareDebugNode<'db, 'a, H, C>
 where

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -26,7 +26,7 @@ use nibbleslice::NibbleSlice;
 use ::core_::marker::PhantomData;
 use ::core_::mem;
 use ::core_::ops::Index;
-use ::core_::{fmt::Debug, hash::Hash};
+use ::core_::hash::Hash;
 
 #[cfg(feature = "std")]
 use ::std::collections::{HashSet, VecDeque};
@@ -36,6 +36,7 @@ use ::alloc::collections::vec_deque::VecDeque;
 
 #[cfg(not(feature = "std"))]
 use ::hashbrown::HashSet;
+//use ::hashmap_core::HashSet;
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
@@ -90,7 +91,7 @@ enum Node<H> {
 
 impl<O> Node<O>
 where
-	O: AsRef<[u8]> + AsMut<[u8]> + Default + Debug + PartialEq + Eq + Hash + Send + Sync + Clone + Copy
+	O: AsRef<[u8]> + AsMut<[u8]> + Default + crate::DebugIfStd + PartialEq + Eq + Hash + Send + Sync + Clone + Copy
 {
 	// load an inline node into memory or get the hash to do the lookup later.
 	fn inline_or_hash<C, H>(

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -23,11 +23,25 @@ use super::{DBValue, node::NodeKey};
 use hash_db::{HashDB, Hasher};
 use nibbleslice::NibbleSlice;
 
-use std::collections::{HashSet, VecDeque};
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Index;
-use std::{fmt::Debug, hash::Hash};
+use ::core_::marker::PhantomData;
+use ::core_::mem;
+use ::core_::ops::Index;
+use ::core_::{fmt::Debug, hash::Hash};
+
+#[cfg(feature = "std")]
+use ::std::collections::{HashSet, VecDeque};
+
+#[cfg(not(feature = "std"))]
+use ::alloc::collections::vec_deque::VecDeque;
+
+#[cfg(not(feature = "std"))]
+use ::hashbrown::HashSet;
+
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 // For lookups into the Node storage buffer.
 // This is deliberately non-copyable.

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -35,8 +35,7 @@ use ::std::collections::{HashSet, VecDeque};
 use ::alloc::collections::vec_deque::VecDeque;
 
 #[cfg(not(feature = "std"))]
-use ::hashbrown::HashSet;
-//use ::hashmap_core::HashSet;
+use ::hashmap_core::HashSet;
 
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 categories = [ "no-std" ]
 
 [dependencies]
-hash-db = { path = "../hash-db", default-features = false, version = "0.11.0"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.11.1"}
 
 [dev-dependencies]
 hex-literal = "0.1"
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.1" }
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.1" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.11.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.11.1" }
 
 [features]
 default = ["std"]

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/parity-common"
@@ -14,7 +14,7 @@ hash-db = { path = "../hash-db", default-features = false }
 hex-literal = "0.1"
 keccak-hasher = { path = "../test-support/keccak-hasher" }
 trie-standardmap = { path = "../test-support/trie-standardmap" }
-reference-trie = { path = "../test-support/reference-trie" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This PR allows trie to run in no_std mode : eg https://github.com/paritytech/substrate/compare/master...cheme:no_std-trie 
It requires 'alloc' so it is no_std for nightly only.
This replies to https://github.com/paritytech/substrate/issues/1574 .

For memory-db and trie I use 'hashmap_core' crate, this is not a very good choice as 'hashbrown' is more maintained, and long term it should be replaced by 'hashbrown'. I did not use 'hashbrown' because the way we switch to 'no_std' is done through feature declaration (feature 'nightly'), that means that I have to propagate the feature up to the no_std building crate (see commit history of this pr) which is very awkward.

Versioning update is minor and global (I believe it is a choice to keep versioning constistent between trie subproject).

I kept some Debug implementation (basically to use 'expect' on result), I do not think it is too heavy for no_std but it could be a bad choice and we could also avoid 'expect' call in code. Some Debug code is not include but could probably be (full trie debug).
