### PR TITLE
Deprecate heapsize

### DIFF
--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-db"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2.0"

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -32,6 +32,13 @@ pub trait MaybeDebug {}
 #[cfg(not(feature = "std"))]
 impl<T> MaybeDebug for T {}
 
+
+/// Empty prefix constant.
+pub static EMPTY_PREFIX: Prefix<'static> = &[];
+
+/// Prefix byte information for avoding rc.
+pub type Prefix<'a> = &'a[u8];
+
 /// Trait describing an object that can hash a slice of bytes. Used to abstract
 /// other types over the hashing algorithm. Defines a single `hash` method and an
 /// `Out` associated type with the necessary bounds.

--- a/hash256-std-hasher/Cargo.toml
+++ b/hash256-std-hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash256-std-hasher"
 description = "Standard library hasher for 256-bit prehashed keys."
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 homepage = "https://github.com/paritytech/trie"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/paritytech/parity-common"
 license = "Apache-2.0"
 
 [dependencies]
-heapsize = "0.4"
+heapsize = { version = "0.4", optional = true }
 #parity-util-mem = { version = "0.1", path = "../../parity-common/parity-util-mem" }
 parity-util-mem = { version = "0.1", git = "https://github.com/cheme/parity-common", branch = "deprecate_heapsize" }
 hash-db = { path = "../hash-db", version = "0.11.0"}
@@ -19,3 +19,7 @@ criterion = "0.2.8"
 [[bench]]
 name = "bench"
 harness = false
+
+[features]
+default = [ ]
+deprecated = [ "heapsize" ]

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-parity-util-mem = { version = "0.1", git = "https://github.com/cheme/parity-common", branch = "deprecate_heapsize" }
+parity-util-mem = { version = "0.1" }
 hash-db = { path = "../hash-db", default-features = false, version = "0.12.2"}
 hashmap_core = { version = "0.1" }
 

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-parity-util-mem = { version = "0.1" }
+parity-util-mem = { version = "0.1", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.12.3"}
 hashmap_core = { version = "0.1" }
 
@@ -21,6 +21,7 @@ default = ["std"]
 std = [
   "hash-db/std",
   "hashmap_core/disable",
+  "parity-util-mem/std",
 ]
 deprecated = [ "heapsize" ]
 

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -8,7 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = "0.4"
-parity-util-mem = { version = "0.1", path = "../../parity-common/parity-util-mem" }
+#parity-util-mem = { version = "0.1", path = "../../parity-common/parity-util-mem" }
+parity-util-mem = { version = "0.1", git = "https://github.com/cheme/parity-common", branch = "deprecate_heapsize" }
 hash-db = { path = "../hash-db", version = "0.11.0"}
 
 [dev-dependencies]

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -9,11 +9,11 @@ license = "Apache-2.0"
 [dependencies]
 heapsize = { version = "0.4", optional = true }
 parity-util-mem = { version = "0.1" }
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.2"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.12.3"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.2"}
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.3"}
 criterion = "0.2.8"
 
 [features]

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.12.0"
+version = "0.11.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/parity-common"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/parity-common"
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = "0.4"
+parity-util-mem = { version = "0.1", path = "../../parity-common/parity-util-mem" }
 hash-db = { path = "../hash-db", version = "0.11.0"}
 
 [dev-dependencies]

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-#parity-util-mem = { version = "0.1", path = "../../parity-common/parity-util-mem" }
 parity-util-mem = { version = "0.1", git = "https://github.com/cheme/parity-common", branch = "deprecate_heapsize" }
 hash-db = { path = "../hash-db", default-features = false, version = "0.12.2"}
 hashmap_core = { version = "0.1" }

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -62,6 +62,15 @@ use core::{
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+#[cfg(feature = "std")]
+pub trait MaybeDebug: std::fmt::Debug {}
+#[cfg(feature = "std")]
+impl<T: std::fmt::Debug> MaybeDebug for T {}
+#[cfg(not(feature = "std"))]
+pub trait MaybeDebug {}
+#[cfg(not(feature = "std"))]
+impl<T> MaybeDebug for T {}
+
 /// Reference-counted memory-based `HashDB` implementation.
 ///
 /// Use `new()` to create a new database. Insert items with `insert()`, remove items

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -109,7 +109,7 @@ use alloc::vec::Vec;
 ///   assert!(!m.contains(&k, &[]));
 /// }
 /// ```
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct MemoryDB<H, KF, T>
 	where
 	H: KeyHasher,
@@ -121,6 +121,33 @@ pub struct MemoryDB<H, KF, T>
 	_kf: PhantomData<KF>,
 }
 
+impl<H, KF, T> PartialEq<MemoryDB<H, KF, T>> for MemoryDB<H, KF, T>
+	where 
+	H: KeyHasher,
+	KF: KeyFunction<H>,
+	<KF as KeyFunction<H>>::Key: Eq + MaybeDebug,
+	T: Eq + MaybeDebug,
+{
+	fn eq(&self, other: &MemoryDB<H, KF, T>) -> bool {
+		for a in self.data.iter() {
+			match other.data.get(&a.0) {
+				Some(v) if v != a.1 => return false,
+				None => return false,
+				_ => (),
+			}
+		}
+		true
+	}
+}
+
+impl<H, KF, T> Eq for MemoryDB<H, KF, T>
+	where 
+	H: KeyHasher,
+	KF: KeyFunction<H>,
+	<KF as KeyFunction<H>>::Key: Eq + MaybeDebug,
+				T: Eq + MaybeDebug,
+{}
+ 
 pub trait KeyFunction<H: KeyHasher> {
 	type Key: Send + Sync + Clone + hash::Hash + Eq;
 

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -140,6 +140,7 @@ pub fn hash_key<H: KeyHasher>(key: &H::Out, _prefix: &[u8]) -> H::Out {
 	key.clone()
 }
 
+#[derive(Clone,Debug)]
 /// Key function that only uses the hash
 pub struct HashKey<H: KeyHasher>(PhantomData<H>);
 
@@ -151,6 +152,7 @@ impl<H: KeyHasher> KeyFunction<H> for HashKey<H> {
 	}
 }
 
+#[derive(Clone,Debug)]
 /// Key function that concatenates prefix and hash.
 pub struct PrefixedKey<H: KeyHasher>(PhantomData<H>);
 

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -16,11 +16,13 @@
 
 extern crate hash_db;
 extern crate parity_util_mem as malloc_size_of;
+#[cfg(feature = "deprecated")]
 extern crate heapsize;
 #[cfg(test)] extern crate keccak_hasher;
 
 use hash_db::{HashDB, HashDBRef, PlainDB, PlainDBRef, Hasher as KeyHasher, AsHashDB, AsPlainDB};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+#[cfg(feature = "deprecated")]
 use heapsize::HeapSizeOf;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -218,6 +220,7 @@ impl<'a, H: KeyHasher, T> MemoryDB<H, T> where T: From<&'a [u8]> {
 	}
 }
 
+#[cfg(feature = "deprecated")]
 impl<H, T> MemoryDB<H, T>
 where
 	H: KeyHasher,

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
 extern crate hash_db;
-extern crate parity_util_mem as malloc_size_of;
+extern crate parity_util_mem;
 #[cfg(feature = "deprecated")]
 #[cfg(feature = "std")]
 extern crate heapsize;
@@ -29,7 +29,7 @@ extern crate alloc;
 #[cfg(test)] extern crate keccak_hasher;
 
 use hash_db::{HashDB, HashDBRef, PlainDB, PlainDBRef, Hasher as KeyHasher, AsHashDB, AsPlainDB};
-use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+use parity_util_mem::{MallocSizeOf, MallocSizeOfOps};
 #[cfg(feature = "deprecated")]
 #[cfg(feature = "std")]
 use heapsize::HeapSizeOf;
@@ -308,7 +308,7 @@ where
 	T: HeapSizeOf,
 	KF: KeyFunction<H>,
 {
-	#[deprecated(since="0.12.0", note="please use `malloc_size_of` instead")]
+	#[deprecated(since="0.12.0", note="please use `size_of` instead")]
 	/// Returns the size of allocated heap memory
 	pub fn mem_used(&self) -> usize {
 		0//self.data.heap_size_of_children()

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 tiny-keccak = "1.4.2"
-hash-db = { path = "../../hash-db", default-features = false, version = "0.12.2" }
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.2" }
+hash-db = { path = "../../hash-db", default-features = false, version = "0.12.3" }
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.3" }
 
 [features]
 default = ["std"]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "reference-trie"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.12.2"}
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.2" }
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.12.2"}
-trie-root = { path = "../../trie-root", default-features = false, version = "0.12.2" }
+hash-db = { path = "../../hash-db" , version = "0.12.3"}
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.3" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.3" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.12.3"}
+trie-root = { path = "../../trie-root", default-features = false, version = "0.12.3" }
 parity-codec = "3.0"
 parity-codec-derive = "3.0"
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.12.2" }
+trie-bench = { path = "../trie-bench", version = "0.12.3" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 keccak-hasher = { path = "../keccak-hasher", version = "0.11.0" }
 trie-standardmap = { path = "../trie-standardmap", version  = "0.11.0" }
 hash-db = { path = "../../hash-db" , version = "0.11.0"}
-memory-db = { path = "../../memory-db", version = "0.11.0" }
+memory-db = { path = "../../memory-db", version = "0.12.0" }
 trie-root = { path = "../../trie-root", version = "0.11.0" }
 trie-db = { path = "../../trie-db", version = "0.11.0" }
 criterion = "0.2.8"

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.2" }
-trie-standardmap = { path = "../trie-standardmap", version  = "0.12.2" }
-hash-db = { path = "../../hash-db" , version = "0.12.2"}
-memory-db = { path = "../../memory-db", version = "0.12.2" }
-trie-root = { path = "../../trie-root", version = "0.12.2" }
-trie-db = { path = "../../trie-db", version = "0.12.2" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.3" }
+trie-standardmap = { path = "../trie-standardmap", version  = "0.12.3" }
+hash-db = { path = "../../hash-db" , version = "0.12.3"}
+memory-db = { path = "../../memory-db", version = "0.12.3" }
+trie-root = { path = "../../trie-root", version = "0.12.3" }
+trie-db = { path = "../../trie-db", version = "0.12.3" }
 criterion = "0.2.8"
 parity-codec = "3.0"

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 keccak-hasher = { path = "../keccak-hasher", version = "0.11.0" }
 trie-standardmap = { path = "../trie-standardmap", version  = "0.11.0" }
 hash-db = { path = "../../hash-db" , version = "0.11.0"}
-memory-db = { path = "../../memory-db", version = "0.12.0" }
+memory-db = { path = "../../memory-db", version = "0.11.0" }
 trie-root = { path = "../../trie-root", version = "0.11.0" }
 trie-db = { path = "../../trie-db", version = "0.11.0" }
 criterion = "0.2.8"

--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.2"}
-hash-db = { path = "../../hash-db" , version = "0.12.2"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.3"}
+hash-db = { path = "../../hash-db" , version = "0.12.3"}

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -10,17 +10,17 @@ license = "Apache-2.0"
 log = "0.4"
 rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10", default-features = false }
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.2"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.12.3"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.12.2" }
-trie-root = { path = "../trie-root", version = "0.12.2"}
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.2" }
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.2" }
+memory-db = { path = "../memory-db", version = "0.12.3" }
+trie-root = { path = "../trie-root", version = "0.12.3"}
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.3" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.3" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.12.2" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.12.3" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -14,7 +14,7 @@ hash-db = { path = "../hash-db" , version = "0.11.0"}
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.12.0" }
+memory-db = { path = "../memory-db", version = "0.11.0" }
 trie-root = { path = "../trie-root", version = "0.11.0"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -14,7 +14,7 @@ hash-db = { path = "../hash-db" , version = "0.11.0"}
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.11.0" }
+memory-db = { path = "../memory-db", version = "0.12.0" }
 trie-root = { path = "../trie-root", version = "0.11.0"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.11.0" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.11.0" }

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/trie"
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 categories = [ "no-std" ]
 
 [dependencies]
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.2"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.12.3"}
 
 [dev-dependencies]
 hex-literal = "0.1"
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.2" }
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.2" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.3" }
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.3" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.12.2" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.12.3" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This PR deprecates heapsize (currently keeping it behind an optional feature).
It uses parity-util-mem instead.
~~This PR can be reviewed but **cannot merge** until PR ~~https://github.com/paritytech/parity-common/pull/93~~ https://github.com/paritytech/parity-common/pull/94 get approved and the crate published.
The versioning was not yet updated.~~