### PR TITLE
[trie-standardmap] remove unused dep; bump version to 0.12.3

### DIFF
--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "trie-standardmap"
 description = "Standard test map for profiling tries"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
 keccak-hasher = { path = "../keccak-hasher", version = "0.12.2"}
 hash-db = { path = "../../hash-db" , version = "0.12.2"}
-criterion = "0.2.8"


### PR DESCRIPTION
needed for https://github.com/paritytech/parity-ethereum/pull/10670:
there are some problems compiling `criterion` > `0.2.5`:
```rust
error[E0599]: no method named `fill_bytes` found for type `std::cell::RefMut<'_, rand_os::OsRng>` in the current scope
  --> /path/to/.cargo/registry/src/github.com-1ecc6299db9ec823/criterion-0.2.11/src/stats/rand_util.rs:16:24
   |
16 |         r.borrow_mut().fill_bytes(&mut seed);
   |                        ^^^^^^^^^^
   |
   = help: items from traits can only be used if the trait is in scope
   = note: the following trait is implemented but not in scope, perhaps add a `use` for it:
           `use rand_os::rand_core::RngCore;`
```