### PR TITLE
fix no_std build for memory-db.

### DIFF
--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-db"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2.0"

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -87,12 +87,12 @@ pub trait PlainDBRef<K, V> {
 	fn contains(&self, key: &K) -> bool;
 }
 
-impl<'a, K, V> PlainDBRef<K, V> for &'a PlainDB<K, V> {
+impl<'a, K, V> PlainDBRef<K, V> for &'a dyn PlainDB<K, V> {
 	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
 	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
 }
 
-impl<'a, K, V> PlainDBRef<K, V> for &'a mut PlainDB<K, V> {
+impl<'a, K, V> PlainDBRef<K, V> for &'a mut dyn PlainDB<K, V> {
 	fn get(&self, key: &K) -> Option<V> { PlainDB::get(*self, key) }
 	fn contains(&self, key: &K) -> bool { PlainDB::contains(*self, key) }
 }
@@ -129,12 +129,12 @@ pub trait HashDBRef<H: Hasher, T> {
 	fn contains(&self, key: &H::Out, prefix: &[u8]) -> bool;
 }
 
-impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a HashDB<H, T> {
+impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a dyn HashDB<H, T> {
 	fn get(&self, key: &H::Out, prefix: &[u8]) -> Option<T> { HashDB::get(*self, key, prefix) }
 	fn contains(&self, key: &H::Out, prefix: &[u8]) -> bool { HashDB::contains(*self, key, prefix) }
 }
 
-impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut HashDB<H, T> {
+impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut dyn HashDB<H, T> {
 	fn get(&self, key: &H::Out, prefix: &[u8]) -> Option<T> { HashDB::get(*self, key, prefix) }
 	fn contains(&self, key: &H::Out, prefix: &[u8]) -> bool { HashDB::contains(*self, key, prefix) }
 }
@@ -142,24 +142,24 @@ impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut HashDB<H, T> {
 /// Upcast trait for HashDB.
 pub trait AsHashDB<H: Hasher, T> {
 	/// Perform upcast to HashDB for anything that derives from HashDB.
-	fn as_hash_db(&self) -> &HashDB<H, T>;
+	fn as_hash_db(&self) -> &dyn HashDB<H, T>;
 	/// Perform mutable upcast to HashDB for anything that derives from HashDB.
-	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (HashDB<H, T> + 'a);
+	fn as_hash_db_mut<'a>(&'a mut self) -> &'a mut (dyn HashDB<H, T> + 'a);
 }
 
 /// Upcast trait for PlainDB.
 pub trait AsPlainDB<K, V> {
 	/// Perform upcast to PlainDB for anything that derives from PlainDB.
-	fn as_plain_db(&self) -> &PlainDB<K, V>;
+	fn as_plain_db(&self) -> &dyn PlainDB<K, V>;
 	/// Perform mutable upcast to PlainDB for anything that derives from PlainDB.
-	fn as_plain_db_mut<'a>(&'a mut self) -> &'a mut (PlainDB<K, V> + 'a);
+	fn as_plain_db_mut<'a>(&'a mut self) -> &'a mut (dyn PlainDB<K, V> + 'a);
 }
 
 // NOTE: There used to be a `impl<T> AsHashDB for T` but that does not work with generics. See https://stackoverflow.com/questions/48432842/implementing-a-trait-for-reference-and-non-reference-types-causes-conflicting-im
 // This means we need concrete impls of AsHashDB in several places, which somewhat defeats the point of the trait.
-impl<'a, H: Hasher, T> AsHashDB<H, T> for &'a mut HashDB<H, T> {
-	fn as_hash_db(&self) -> &HashDB<H, T> { &**self }
-	fn as_hash_db_mut<'b>(&'b mut self) -> &'b mut (HashDB<H, T> + 'b) { &mut **self }
+impl<'a, H: Hasher, T> AsHashDB<H, T> for &'a mut dyn HashDB<H, T> {
+	fn as_hash_db(&self) -> &dyn HashDB<H, T> { &**self }
+	fn as_hash_db_mut<'b>(&'b mut self) -> &'b mut (dyn HashDB<H, T> + 'b) { &mut **self }
 }
 
 #[cfg(feature = "std")]

--- a/hash256-std-hasher/Cargo.toml
+++ b/hash256-std-hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash256-std-hasher"
 description = "Standard library hasher for 256-bit prehashed keys."
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 homepage = "https://github.com/paritytech/trie"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -9,11 +9,11 @@ license = "Apache-2.0"
 [dependencies]
 heapsize = { version = "0.4", optional = true }
 parity-util-mem = { version = "0.1", default-features = false }
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.3"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.12.4"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.3"}
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.4"}
 criterion = "0.2.8"
 
 [features]

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -389,12 +389,9 @@ where
 		use core::mem::size_of;
 		let mut n = self.data.capacity() * (size_of::<T>() + size_of::<H>() + size_of::<usize>());
 		for (k, v) in self.data.iter() {
-			n += k.size_of(ops);
-			n += v.size_of(ops);
+			n += k.size_of(ops) + v.size_of(ops);
 		}
-		n
-			+ self.null_node_data.size_of(ops)
-			+ self.hashed_null_node.size_of(ops)
+		n + self.null_node_data.size_of(ops) + self.hashed_null_node.size_of(ops)
 	}
 }
 

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -354,8 +354,9 @@ where
 	}
 }
 
-// not no_std implementation requires that hasmap core
-// got its implementation in parity-util-mem
+// `no_std` implementation requires that hasmap
+// is implementated in parity-util-mem, that
+// is currently not the case.
 #[cfg(feature = "std")]
 impl<H, KF, T> MallocSizeOf for MemoryDB<H, KF, T>
 where
@@ -372,10 +373,9 @@ where
 	}
 }
 
-// This is temporary code and should be in
-// parity-util-mem, but hashmap_core will probably
-// get replaced at some point by hashbrown so
-// this is a pragmatic temporary solution.
+// This is temporary code, we should use
+// `parity-util-mem`, see
+// https://github.com/paritytech/trie/issues/21
 #[cfg(not(feature = "std"))]
 impl<H, KF, T> MallocSizeOf for MemoryDB<H, KF, T>
 where

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 tiny-keccak = "1.4.2"
-hash-db = { path = "../../hash-db", default-features = false, version = "0.12.3" }
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.3" }
+hash-db = { path = "../../hash-db", default-features = false, version = "0.12.4" }
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.4" }
 
 [features]
 default = ["std"]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -8,11 +8,11 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.12.3"}
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.3" }
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.3" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.12.3"}
-trie-root = { path = "../../trie-root", default-features = false, version = "0.12.3" }
+hash-db = { path = "../../hash-db" , version = "0.12.4"}
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.4" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.4" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.12.4"}
+trie-root = { path = "../../trie-root", default-features = false, version = "0.12.4" }
 parity-codec = { version = "4.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -7,11 +7,11 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.3" }
-trie-standardmap = { path = "../trie-standardmap", version  = "0.12.3" }
-hash-db = { path = "../../hash-db" , version = "0.12.3"}
-memory-db = { path = "../../memory-db", version = "0.12.3" }
-trie-root = { path = "../../trie-root", version = "0.12.3" }
-trie-db = { path = "../../trie-db", version = "0.12.3" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.4" }
+trie-standardmap = { path = "../trie-standardmap", version  = "0.12.4" }
+hash-db = { path = "../../hash-db" , version = "0.12.4"}
+memory-db = { path = "../../memory-db", version = "0.12.4" }
+trie-root = { path = "../../trie-root", version = "0.12.4" }
+trie-db = { path = "../../trie-db", version = "0.12.4" }
 criterion = "0.2.8"
 parity-codec = "4.0"

--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "trie-standardmap"
 description = "Standard test map for profiling tries"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.3"}
-hash-db = { path = "../../hash-db" , version = "0.12.3"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.12.4"}
+hash-db = { path = "../../hash-db" , version = "0.12.4"}

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -10,15 +10,15 @@ license = "Apache-2.0"
 log = "0.4"
 rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10", default-features = false }
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.3"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.12.4"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.12.3" }
-trie-root = { path = "../trie-root", version = "0.12.3"}
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.3" }
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.3" }
+memory-db = { path = "../memory-db", version = "0.12.4" }
+trie-root = { path = "../trie-root", version = "0.12.4"}
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.4" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.4" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
 reference-trie = { path = "../test-support/reference-trie", version = "0.13.0" }
 hex-literal = "0.1"

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -39,12 +39,15 @@ where
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db HashDBRef<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn new(
+		db: &'db dyn HashDBRef<H, DBValue>,
+		root: &'db H::Out,
+	) -> Result<Self, H::Out, C::Error> {
 		Ok(FatDB { raw: TrieDB::new(db, root)? })
 	}
 
 	/// Get the backing database.
-	pub fn db(&self) -> &HashDBRef<H, DBValue> { self.raw.db() }
+	pub fn db(&self) -> &dyn HashDBRef<H, DBValue> { self.raw.db() }
 }
 
 impl<'db, H, C> Trie<H, C> for FatDB<'db, H, C>
@@ -64,7 +67,11 @@ where
 		self.raw.get_with(H::hash(key).as_ref(), query)
 	}
 
-	fn iter<'a>(&'a self) -> Result<Box<TrieIterator<H, C, Item = TrieItem<H::Out, C::Error>> + 'a>, <H as Hasher>::Out, C::Error> {
+	fn iter<'a>(&'a self) -> Result<
+		Box<dyn TrieIterator<H, C, Item = TrieItem<H::Out, C::Error>> + 'a>,
+		<H as Hasher>::Out,
+		C::Error,
+	> {
 		FatDBIterator::<H, C>::new(&self.raw).map(|iter| Box::new(iter) as Box<_>)
 	}
 }

--- a/trie-db/src/fatdbmut.rs
+++ b/trie-db/src/fatdbmut.rs
@@ -36,24 +36,27 @@ where
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Self {
+	pub fn new(db: &'db mut dyn HashDB<H, DBValue>, root: &'db mut H::Out) -> Self {
 		FatDBMut { raw: TrieDBMut::new(db, root) }
 	}
 
 	/// Create a new trie with the backing database `db` and `root`.
 	///
 	/// Returns an error if root does not exist.
-	pub fn from_existing(db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn from_existing(
+		db: &'db mut dyn HashDB<H, DBValue>,
+		root: &'db mut H::Out,
+	) -> Result<Self, H::Out, C::Error> {
 		Ok(FatDBMut { raw: TrieDBMut::from_existing(db, root)? })
 	}
 
 	/// Get the backing database.
-	pub fn db(&self) -> &HashDB<H, DBValue> {
+	pub fn db(&self) -> &dyn HashDB<H, DBValue> {
 		self.raw.db()
 	}
 
 	/// Get the backing database.
-	pub fn db_mut(&mut self) -> &mut HashDB<H, DBValue> {
+	pub fn db_mut(&mut self) -> &mut dyn HashDB<H, DBValue> {
 		self.raw.db_mut()
 	}
 }

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -27,7 +27,7 @@ use alloc::boxed::Box;
 /// Trie lookup helper object.
 pub struct Lookup<'a, H: Hasher + 'a, C: NodeCodec<H>, Q: Query<H>> {
 	/// database to query from.
-	pub db: &'a HashDBRef<H, DBValue>,
+	pub db: &'a dyn HashDBRef<H, DBValue>,
 	/// Query object to record nodes and transform data.
 	pub query: Q,
 	/// Hash to start at

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -41,7 +41,10 @@ where
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
 	/// Returns an error if root does not exist.
-	pub fn new(db: &'db HashDBRef<H, DBValue>, root: &'db H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn new(
+		db: &'db dyn HashDBRef<H, DBValue>,
+		root: &'db H::Out,
+	) -> Result<Self, H::Out, C::Error> {
 		Ok(SecTrieDB { raw: TrieDB::new(db, root)? })
 	}
 
@@ -73,7 +76,11 @@ where
 		self.raw.get_with(H::hash(key).as_ref(), query)
 	}
 
-	fn iter<'a>(&'a self) -> Result<Box<TrieIterator<H, C, Item = TrieItem<H::Out, C::Error>> + 'a>, H::Out, C::Error> {
+	fn iter<'a>(&'a self) -> Result<
+		Box<dyn TrieIterator<H, C, Item = TrieItem<H::Out, C::Error>> + 'a>,
+		H::Out,
+		C::Error,
+	> {
 		TrieDB::iter(&self.raw)
 	}
 }

--- a/trie-db/src/sectriedbmut.rs
+++ b/trie-db/src/sectriedbmut.rs
@@ -35,22 +35,25 @@ where
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Self {
+	pub fn new(db: &'db mut dyn HashDB<H, DBValue>, root: &'db mut H::Out) -> Self {
 		SecTrieDBMut { raw: TrieDBMut::new(db, root) }
 	}
 
 	/// Create a new trie with the backing database `db` and `root`.
 	///
 	/// Returns an error if root does not exist.
-	pub fn from_existing(db: &'db mut HashDB<H, DBValue>, root: &'db mut H::Out) -> Result<Self, H::Out, C::Error> {
+	pub fn from_existing(
+		db: &'db mut dyn HashDB<H, DBValue>,
+		root: &'db mut H::Out,
+	) -> Result<Self, H::Out, C::Error> {
 		Ok(SecTrieDBMut { raw: TrieDBMut::from_existing(db, root)? })
 	}
 
 	/// Get the backing database.
-	pub fn db(&self) -> &HashDB<H, DBValue> { self.raw.db() }
+	pub fn db(&self) -> &dyn HashDB<H, DBValue> { self.raw.db() }
 
 	/// Get the backing database.
-	pub fn db_mut(&mut self) -> &mut HashDB<H, DBValue> { self.raw.db_mut() }
+	pub fn db_mut(&mut self) -> &mut dyn HashDB<H, DBValue> { self.raw.db_mut() }
 }
 
 impl<'db, H, C> TrieMut<H, C> for SecTrieDBMut<'db, H, C>

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/trie"
@@ -8,12 +8,12 @@ license = "Apache-2.0"
 categories = [ "no-std" ]
 
 [dependencies]
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.3"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.12.4"}
 
 [dev-dependencies]
 hex-literal = "0.1"
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.3" }
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.3" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.4" }
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.4" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
 reference-trie = { path = "../test-support/reference-trie", version = "0.13.0" }
 


### PR DESCRIPTION
Version 12.3 broke no_std compatibility.
This PR fixes that.
The PR also removes some warning (add 'dyn' info on types).