### PR TITLE
Parity util mem update and verision alignment

### DIFF
--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-db"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2.0"

--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-db"
-version = "0.12.4"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2.0"

--- a/hash256-std-hasher/Cargo.toml
+++ b/hash256-std-hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash256-std-hasher"
 description = "Standard library hasher for 256-bit prehashed keys."
-version = "0.12.4"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 homepage = "https://github.com/paritytech/trie"

--- a/hash256-std-hasher/Cargo.toml
+++ b/hash256-std-hasher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hash256-std-hasher"
 description = "Standard library hasher for 256-bit prehashed keys."
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 homepage = "https://github.com/paritytech/trie"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -9,11 +9,11 @@ license = "Apache-2.0"
 [dependencies]
 heapsize = { version = "0.4", optional = true }
 parity-util-mem = { version = "0.2", default-features = false }
-hash-db = { path = "../hash-db", default-features = false, version = "0.13.1"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.14.0"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.13.1"}
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.14.0"}
 criterion = "0.2.8"
 
 [features]

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.12.5"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -9,11 +9,11 @@ license = "Apache-2.0"
 [dependencies]
 heapsize = { version = "0.4", optional = true }
 parity-util-mem = { version = "0.2", default-features = false }
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.4"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.13.1"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.4"}
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.13.1"}
 criterion = "0.2.8"
 
 [features]

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.12.4"
+version = "0.12.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-parity-util-mem = { version = "0.1", default-features = false }
+parity-util-mem = { version = "0.2", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.12.4"}
 hashmap_core = { version = "0.1" }
 

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 tiny-keccak = "1.4.2"
-hash-db = { path = "../../hash-db", default-features = false, version = "0.13.1" }
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.13.1" }
+hash-db = { path = "../../hash-db", default-features = false, version = "0.14.0" }
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.14.0" }
 
 [features]
 default = ["std"]

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.12.4"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 tiny-keccak = "1.4.2"
-hash-db = { path = "../../hash-db", default-features = false, version = "0.12.4" }
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.4" }
+hash-db = { path = "../../hash-db", default-features = false, version = "0.13.1" }
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.13.1" }
 
 [features]
 default = ["std"]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -8,15 +8,15 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.13.1"}
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.13.1" }
-keccak-hasher = { path = "../keccak-hasher", version = "0.13.1" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.13.1"}
-trie-root = { path = "../../trie-root", default-features = false, version = "0.13.1" }
+hash-db = { path = "../../hash-db" , version = "0.14.0"}
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.14.0" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.14.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.14.0"}
+trie-root = { path = "../../trie-root", default-features = false, version = "0.14.0" }
 parity-codec = { version = "4.0", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.13.1" }
+trie-bench = { path = "../trie-bench", version = "0.14.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -8,15 +8,15 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.12.4"}
-hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.12.4" }
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.4" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.12.4"}
-trie-root = { path = "../../trie-root", default-features = false, version = "0.12.4" }
+hash-db = { path = "../../hash-db" , version = "0.13.1"}
+hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.13.1" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.13.1" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.13.1"}
+trie-root = { path = "../../trie-root", default-features = false, version = "0.13.1" }
 parity-codec = { version = "4.0", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.13.0" }
+trie-bench = { path = "../trie-bench", version = "0.13.1" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.13.1" }
-trie-standardmap = { path = "../trie-standardmap", version  = "0.13.1" }
-hash-db = { path = "../../hash-db" , version = "0.13.1"}
-memory-db = { path = "../../memory-db", version = "0.13.1" }
-trie-root = { path = "../../trie-root", version = "0.13.1" }
-trie-db = { path = "../../trie-db", version = "0.13.1" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.14.0" }
+trie-standardmap = { path = "../trie-standardmap", version  = "0.14.0" }
+hash-db = { path = "../../hash-db" , version = "0.14.0"}
+memory-db = { path = "../../memory-db", version = "0.14.0" }
+trie-root = { path = "../../trie-root", version = "0.14.0" }
+trie-db = { path = "../../trie-db", version = "0.14.0" }
 criterion = "0.2.8"
 parity-codec = "4.0"

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.4" }
-trie-standardmap = { path = "../trie-standardmap", version  = "0.12.4" }
-hash-db = { path = "../../hash-db" , version = "0.12.4"}
-memory-db = { path = "../../memory-db", version = "0.12.4" }
-trie-root = { path = "../../trie-root", version = "0.12.4" }
-trie-db = { path = "../../trie-db", version = "0.12.4" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.13.1" }
+trie-standardmap = { path = "../trie-standardmap", version  = "0.13.1" }
+hash-db = { path = "../../hash-db" , version = "0.13.1"}
+memory-db = { path = "../../memory-db", version = "0.13.1" }
+trie-root = { path = "../../trie-root", version = "0.13.1" }
+trie-db = { path = "../../trie-db", version = "0.13.1" }
 criterion = "0.2.8"
 parity-codec = "4.0"

--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "trie-standardmap"
 description = "Standard test map for profiling tries"
-version = "0.12.4"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.12.4"}
-hash-db = { path = "../../hash-db" , version = "0.12.4"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.13.1"}
+hash-db = { path = "../../hash-db" , version = "0.13.1"}

--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "trie-standardmap"
 description = "Standard test map for profiling tries"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.13.1"}
-hash-db = { path = "../../hash-db" , version = "0.13.1"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.14.0"}
+hash-db = { path = "../../hash-db" , version = "0.14.0"}

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -10,17 +10,17 @@ license = "Apache-2.0"
 log = "0.4"
 rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10", default-features = false }
-hash-db = { path = "../hash-db", default-features = false, version = "0.13.1"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.14.0"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.13.1" }
-trie-root = { path = "../trie-root", version = "0.13.1"}
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.13.1" }
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.13.1" }
+memory-db = { path = "../memory-db", version = "0.14.0" }
+trie-root = { path = "../trie-root", version = "0.14.0"}
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.14.0" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.14.0" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.13.1" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.14.0" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.12.4"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -10,17 +10,17 @@ license = "Apache-2.0"
 log = "0.4"
 rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10", default-features = false }
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.4"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.13.1"}
 hashmap_core = { version = "0.1" }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.12.4" }
-trie-root = { path = "../trie-root", version = "0.12.4"}
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.4" }
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.4" }
+memory-db = { path = "../memory-db", version = "0.13.1" }
+trie-root = { path = "../trie-root", version = "0.13.1"}
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.13.1" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.13.1" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.13.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.13.1" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -667,38 +667,38 @@ mod tests {
                                     slice: ,
                                     value: [
                                         65,
-                                        65
-                                    ]
+                                        65,
+                                    ],
                                 },
                                 Node::Leaf {
                                     index: 2,
                                     slice: ,
                                     value: [
                                         65,
-                                        66
-                                    ]
-                                }
+                                        66,
+                                    ],
+                                },
                             ],
-                            value: None
-                        }
+                            value: None,
+                        },
                     ],
                     value: Some(
                         [
-                            65
-                        ]
-                    )
+                            65,
+                        ],
+                    ),
                 },
                 Node::Leaf {
                     index: 2,
                     slice: ,
                     value: [
-                        66
-                    ]
-                }
+                        66,
+                    ],
+                },
             ],
-            value: None
-        }
-    }
+            value: None,
+        },
+    },
 }");
 	}
 

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.12.4"
+version = "0.13.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/trie"
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 categories = [ "no-std" ]
 
 [dependencies]
-hash-db = { path = "../hash-db", default-features = false, version = "0.12.4"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.13.1"}
 
 [dev-dependencies]
 hex-literal = "0.1"
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.12.4" }
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.12.4" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.13.1" }
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.13.1" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.13.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.13.1" }
 
 [features]
 default = ["std"]

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/trie"
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 categories = [ "no-std" ]
 
 [dependencies]
-hash-db = { path = "../hash-db", default-features = false, version = "0.13.1"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.14.0"}
 
 [dev-dependencies]
 hex-literal = "0.1"
-keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.13.1" }
-trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.13.1" }
+keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.14.0" }
+trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.14.0" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.13.1" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.14.0" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This pr update parity-util-mem to 0.2 (no clear_on_drop dep).
And align versioning between all crates.
Also a test format fix.