### PR TITLE
Update codec + new release of trie-bench

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -16,7 +16,7 @@ trie-root = { path = "../../trie-root", default-features = false, version = "0.1
 parity-scale-codec = { version = "1.0.3", features = ["derive"]}
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.14.0" }
+trie-bench = { path = "../trie-bench", version = "0.15.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -8,12 +8,12 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.14.0"}
+hash-db = { path = "../../hash-db" , version = "0.14.0" }
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.14.0" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.14.0" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.14.0"}
+trie-db = { path = "../../trie-db", default-features = false, version = "0.14.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.14.0" }
-parity-scale-codec = { version = "1.0.3", features = ["derive"]}
+parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 
 [dev-dependencies]
 trie-bench = { path = "../trie-bench", version = "0.15.0" }

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -13,7 +13,7 @@ hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.14.0" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.14.0" }
 trie-db = { path = "../../trie-db", default-features = false, version = "0.14.0"}
 trie-root = { path = "../../trie-root", default-features = false, version = "0.14.0" }
-parity-codec = { version = "4.0", features = ["derive"] }
+parity-scale-codec = { version = "1.0.3", features = ["derive"]}
 
 [dev-dependencies]
 trie-bench = { path = "../trie-bench", version = "0.14.0" }

--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -17,7 +17,7 @@
 use std::fmt;
 use std::error::Error as StdError;
 use std::iter::once;
-use parity_codec::{Decode, Input, Output, Encode, Compact};
+use parity_scale_codec::{Decode, Input, Output, Encode, Compact};
 use trie_root::Hasher;
 use trie_db::{node::Node, triedbmut::ChildReference, DBValue};
 use keccak_hasher::KeccakHasher;

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+repository = "https://github.com/paritytech/parity/"
 license = "Apache-2.0"
 edition = "2018"
 
@@ -14,4 +15,4 @@ memory-db = { path = "../../memory-db", version = "0.14.0" }
 trie-root = { path = "../../trie-root", version = "0.14.0" }
 trie-db = { path = "../../trie-db", version = "0.14.0" }
 criterion = "0.2.8"
-parity-codec = "4.0"
+parity-scale-codec = { version = "1.0.3" }

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -3,7 +3,7 @@ name = "trie-bench"
 description = "Standard benchmarking suite for tries"
 version = "0.15.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-repository = "https://github.com/paritytech/parity/"
+repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
 edition = "2018"
 

--- a/test-support/trie-bench/src/lib.rs
+++ b/test-support/trie-bench/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! Standard trie benchmarking tool.
 
-use parity_codec::{Encode, Compact};
+use parity_scale_codec::{Encode, Compact};
 use criterion::{Criterion, black_box, Fun};
 use keccak_hasher::KeccakHasher;
 use hash_db::Hasher;


### PR DESCRIPTION
We just need new version of trie-bench.

and reference-trie desn't need a major version bump because last version is not published