### PR TITLE
update bench version for publishing.

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -16,7 +16,7 @@ trie-root = { path = "../../trie-root", default-features = false, version = "0.1
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.15.0" }
+trie-bench = { path = "../trie-bench", version = "0.16.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"


### PR DESCRIPTION
While publishing 0.15, I realize a 0.15 for bench has already been published.
Therefore this PR update bench to 0.16.