### PR TITLE
export Error for no_std

### DIFF
--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -55,9 +55,6 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 #[cfg(feature = "std")]
-use std::error::Error;
-
-#[cfg(feature = "std")]
 use std::fmt;
 #[cfg(feature = "std")]
 pub trait MaybeDebug: fmt::Debug {}
@@ -95,7 +92,7 @@ pub use self::fatdbmut::FatDBMut;
 pub use self::recorder::{Recorder, Record};
 pub use self::lookup::Lookup;
 pub use self::nibble::{NibbleSlice, nibble_ops};
-pub use node_codec::{NodeCodec, Partial};
+pub use node_codec::{NodeCodec, Partial, Error};
 pub use iter_build::{trie_visit, ProcessEncodedNode,
 	 TrieBuilder, TrieRoot, TrieRootUnhashed};
 

--- a/trie-db/src/node_codec.rs
+++ b/trie-db/src/node_codec.rs
@@ -25,14 +25,12 @@ use std::borrow::Borrow;
 use core::borrow::Borrow;
 
 #[cfg(feature = "std")]
-use std::error::Error;
-
+pub use std::error::Error;
+#[cfg(not(feature = "std"))]
+pub trait Error {}
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-
-#[cfg(not(feature = "std"))]
-pub trait Error {}
 
 #[cfg(not(feature = "std"))]
 impl<T> Error for T {}


### PR DESCRIPTION
I compile `substrate/core/trie` with no_std.
I found the Error in `no_std` is not exported by trie-db.
And `core/trie` seems can not be compiled to `no_std` now time.
```
 core/trie/src/node_codec.rs:43:17
   |
43 | impl<H: Hasher> NodeCodecT<H> for NodeCodec<H> {
   |                 ^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `error::Error`

```