### PR TITLE
Implement OwnedNode using a node decode plan.

### DIFF
--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -39,7 +39,7 @@ pub use trie_db::{
 pub use trie_db::{Record, TrieLayout, TrieConfiguration, nibble_ops};
 pub use trie_root::TrieStream;
 pub mod node {
-	pub use trie_db::node::OwnedNode;
+	pub use trie_db::node::Node;
 }
 
 /// Trie layout using extension nodes.

--- a/trie-db/benches/bench.rs
+++ b/trie-db/benches/bench.rs
@@ -30,6 +30,7 @@ criterion_group!(benches,
 	trie_mut_b,
 	trie_mut_build_a,
 	trie_mut_build_b,
+	trie_iteration,
 	nibble_common_prefix,
 );
 criterion_main!(benches);
@@ -444,4 +445,21 @@ fn trie_mut_build_b(c: &mut Criterion) {
 			reference_trie::calc_root_build(inputc, &mut mdb);
 		}),
 		data);
+}
+
+fn trie_iteration(c: &mut Criterion) {
+	use memory_db::HashKey;
+
+	let input = input2(29, 204800, 32);
+
+	let mut mdb = memory_db::MemoryDB::<_, HashKey<_>, _>::default();
+	let root = reference_trie::calc_root_build(input, &mut mdb);
+
+	c.bench_function("trie_iteration", move |b: &mut Bencher|
+		b.iter(|| {
+			let trie = reference_trie::RefTrieDB::new(&mdb, &root).unwrap();
+			let mut iter = trie_db::TrieDBNodeIterator::new(&trie).unwrap();
+			assert!(iter.all(|result| result.is_ok()));
+		})
+	);
 }

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -62,6 +62,11 @@ impl NibbleSlicePlan {
 		}
 	}
 
+	/// Returns the nibble length of the slice.
+	pub fn len(&self) -> usize {
+		(self.bytes.end - self.bytes.start) * nibble_ops::NIBBLE_PER_BYTE - self.offset
+	}
+
 	/// Build a nibble slice by decoding a byte slice according to the plan. It is the
 	/// responsibility of the caller to ensure that the node plan was created for the argument
 	/// data, otherwise the call decode incorrectly or panic.
@@ -150,6 +155,16 @@ impl<D: Borrow<[u8]>> OwnedNode<D> {
 	pub fn new<H: Hasher, C: NodeCodec<H>>(data: D) -> Result<Self, C::Error> {
 		let plan = C::decode_plan(data.borrow())?;
 		Ok(OwnedNode { data, plan })
+	}
+
+	/// Returns a reference to the backing data.
+	pub fn data(&self) -> &[u8] {
+		self.data.borrow()
+	}
+
+	/// Returns a reference to the node decode plan.
+	pub fn node_plan(&self) -> &NodePlan {
+		&self.plan
 	}
 
 	/// Construct a `Node` by borrowing data from this struct.

--- a/trie-db/src/node_codec.rs
+++ b/trie-db/src/node_codec.rs
@@ -16,7 +16,7 @@
 //! to parametrize the hashes used in the codec.
 
 use hash_db::Hasher;
-use node::Node;
+use node::{Node, NodePlan};
 use ChildReference;
 #[cfg(feature = "std")]
 use std::borrow::Borrow;
@@ -51,8 +51,13 @@ pub trait NodeCodec<H: Hasher>: Sized {
 	/// Get the hashed null node.
 	fn hashed_null_node() -> H::Out;
 
+	/// Decode bytes to a `NodePlan`. Returns `Self::E` on failure.
+	fn decode_plan(data: &[u8]) -> Result<NodePlan, Self::Error>;
+
 	/// Decode bytes to a `Node`. Returns `Self::E` on failure.
-	fn decode(data: &[u8]) -> Result<Node, Self::Error>;
+	fn decode(data: &[u8]) -> Result<Node, Self::Error> {
+		Ok(Self::decode_plan(data)?.build(data))
+	}
 
 	/// Decode bytes to the `Hasher`s output type. Returns `None` on failure.
 	fn try_decode_hash(data: &[u8]) -> Option<H::Out>;

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -90,13 +90,6 @@ where
 	/// Get the backing database.
 	pub fn db(&'db self) -> &'db dyn HashDBRef<L::Hash, DBValue> { self.db }
 
-	/// Get the data of the root node.
-	pub fn root_data(&self) -> Result<DBValue, TrieHash<L>, CError<L>> {
-		self.db
-			.get(self.root, EMPTY_PREFIX)
-			.ok_or_else(|| Box::new(TrieError::InvalidStateRoot(*self.root)))
-	}
-
 	/// Given some node-describing data `node`, and node key return the actual node RLP.
 	/// This could be a simple identity operation in the case that the node is sufficiently small,
 	/// but may require a database lookup.

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -99,8 +99,7 @@ where
 
 	/// Given some node-describing data `node`, and node key return the actual node RLP.
 	/// This could be a simple identity operation in the case that the node is sufficiently small,
-	/// but may require a database lookup. If `is_root_data` then this is root-data and
-	/// is known to be literal.
+	/// but may require a database lookup.
 	///
 	/// Return value is the node data and the node hash if the value was looked up in the database
 	/// or None if it was returned raw.
@@ -109,16 +108,24 @@ where
 	pub(crate) fn get_raw_or_lookup(
 		&self, node: &[u8],
 		partial_key: Prefix,
-	) -> Result<(DBValue, Option<TrieHash<L>>), TrieHash<L>, CError<L>> {
-		match (partial_key.0.is_empty() && partial_key.1.is_none(), L::Codec::try_decode_hash(node)) {
-			(false, Some(key)) => {
-				let data = self.db
-					.get(&key, partial_key)
-					.ok_or_else(|| Box::new(TrieError::IncompleteDatabase(key)))?;
-				Ok((data, Some(key)))
-			}
-			_ => Ok((DBValue::from_slice(node), None)),
-		}
+	) -> Result<(OwnedNode<DBValue>, Option<TrieHash<L>>), TrieHash<L>, CError<L>> {
+		let node_hash = L::Codec::try_decode_hash(node);
+		let node_data = if let Some(key) = node_hash {
+			self.db
+				.get(&key, partial_key)
+				.ok_or_else(|| {
+					if partial_key == EMPTY_PREFIX {
+						Box::new(TrieError::InvalidStateRoot(key))
+					} else {
+						Box::new(TrieError::IncompleteDatabase(key))
+					}
+				})?
+		} else {
+			DBValue::from_slice(node)
+		};
+		let owned_node = OwnedNode::new::<L::Hash, L::Codec>(node_data)
+			.map_err(|e| Box::new(TrieError::DecoderError(node_hash.unwrap_or_default(), e)))?;
+		Ok((owned_node, node_hash))
 	}
 }
 
@@ -170,9 +177,9 @@ where
 	L: TrieLayout,
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		if let Ok((node, _inline)) = self.trie.get_raw_or_lookup(self.node_key, self.partial_key.as_prefix()) {
-			match L::Codec::decode(&node) {
-				Ok(Node::Leaf(slice, value)) =>
+		match self.trie.get_raw_or_lookup(self.node_key, self.partial_key.as_prefix()) {
+			Ok((owned_node, _node_hash)) => match owned_node.node() {
+				Node::Leaf(slice, value) =>
 					match (f.debug_struct("Node::Leaf"), self.index) {
 						(ref mut d, Some(i)) => d.field("index", &i),
 						(ref mut d, _) => d,
@@ -180,13 +187,13 @@ where
 						.field("slice", &slice)
 						.field("value", &value)
 						.finish(),
-				Ok(Node::Extension(slice, item)) =>
+				Node::Extension(slice, item) =>
 					match (f.debug_struct("Node::Extension"), self.index) {
 						(ref mut d, Some(i)) => d.field("index", &i),
 						(ref mut d, _) => d,
 					}
 						.field("slice", &slice)
-						.field("item", &TrieAwareDebugNode{
+						.field("item", &TrieAwareDebugNode {
 							trie: self.trie,
 							node_key: item,
 							partial_key: self.partial_key
@@ -194,7 +201,7 @@ where
 							index: None,
 						})
 						.finish(),
-				Ok(Node::Branch(ref nodes, ref value)) => {
+				Node::Branch(ref nodes, ref value) => {
 					let nodes: Vec<TrieAwareDebugNode<L>> = nodes.into_iter()
 						.enumerate()
 						.filter_map(|(i, n)| n.map(|n| (i, n)))
@@ -214,7 +221,7 @@ where
 						.field("value", &value)
 						.finish()
 				},
-				Ok(Node::NibbledBranch(slice, nodes, value)) => {
+				Node::NibbledBranch(slice, nodes, value) => {
 					let nodes: Vec<TrieAwareDebugNode<L>> = nodes.into_iter()
 						.enumerate()
 						.filter_map(|(i, n)| n.map(|n| (i, n)))
@@ -234,20 +241,13 @@ where
 						.field("value", &value)
 						.finish()
 				},
-				Ok(Node::Empty) => f.debug_struct("Node::Empty").finish(),
-
-				Err(e) => f.debug_struct("BROKEN_NODE")
-					.field("index", &self.index)
-					.field("key", &self.node_key)
-					.field("error", &format!("ERROR decoding node branch Rlp: {}", e))
-					.finish()
-			}
-		} else {
-			f.debug_struct("BROKEN_NODE")
+				Node::Empty => f.debug_struct("Node::Empty").finish(),
+			},
+			Err(e) => f.debug_struct("BROKEN_NODE")
 				.field("index", &self.index)
 				.field("key", &self.node_key)
-				.field("error", &"Not found")
-				.finish()
+				.field("error", &format!("ERROR fetching node: {}", e))
+				.finish(),
 		}
 	}
 }
@@ -258,12 +258,11 @@ where
 	L: TrieLayout,
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		let root_rlp = self.root_data().unwrap();
 		f.debug_struct("TrieDB")
 			.field("hash_count", &self.hash_count)
 			.field("root", &TrieAwareDebugNode {
 				trie: self,
-				node_key: &root_rlp[..],
+				node_key: self.root().as_ref(),
 				partial_key: NibbleVec::new(),
 				index: None,
 			})
@@ -298,16 +297,15 @@ impl<'a, L: TrieLayout> Iterator for TrieDBIterator<'a, L> {
 		while let Some(item) = self.inner.next() {
 			match item {
 				Ok((mut prefix, _, node)) => {
-					let maybe_value = match node.as_ref() {
-						&OwnedNode::Leaf(ref partial, ref value) => {
-						prefix.append(partial);
-							Some(value.as_ref())
+					let maybe_value = match node.node() {
+						Node::Leaf(partial, value) => {
+							prefix.append_partial(partial.right());
+							Some(value)
 						}
-						&OwnedNode::Branch(ref branch) =>
-							branch.get_value(),
-						&OwnedNode::NibbledBranch(ref partial, ref branch) => {
-							prefix.append(partial);
-							branch.get_value()
+						Node::Branch(_, value) => value,
+						Node::NibbledBranch(partial, _, value) => {
+							prefix.append_partial(partial.right());
+							value
 						}
 						_ => None,
 					};


### PR DESCRIPTION
The goal of this change is to remove some of the duplication and inefficiency of `OwnedNode`. `OwnedNode` is a parallel data structure to `Node` that is constructed by copying a lot of data into new allocations. Notably, an `OwnedNode` cannot easily be converted to a `Node` because of alignment issues between `NibbleVec`, which `OwnedNode` uses to represent partial keys, and `NibbleSlice`, which `Node` uses to represent partial keys.

The idea head is for `OwnedNode` to just store an encoded trie node along with a blueprint for quickly decoding into a node. When an encoded node is first decoded, instead of creating a `Node` directly, which has a lifetime, one can construct a `NodePlan` which is an owned structure and can be used to quickly create Nodes thereafter. The `OwnedNode` can be cheaply converted into a `Node` by using the `NodePlan` on its owned data.

*This is a breaking change as it modifies the `NodeCodec` trait and adds a new required method. This probably needs a minor version bump at a minimum.* The actual code changes required to upgrade are fairly minimal though.

Using the newly added benchmark, trie traversal on an in-memory trie is 42% faster.