### PR TITLE
Add NodeHandle enum for node references within Node

### DIFF
--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -683,16 +683,6 @@ impl<H: Hasher> NodeCodec<H> for ReferenceNodeCodec {
 		}
 	}
 
-	fn try_decode_hash(data: &[u8]) -> Option<<H as Hasher>::Out> {
-		if data.len() == H::LENGTH {
-			let mut r = <H as Hasher>::Out::default();
-			r.as_mut().copy_from_slice(data);
-			Some(r)
-		} else {
-			None
-		}
-	}
-
 	fn is_empty_node(data: &[u8]) -> bool {
 		data == <Self as NodeCodec<H>>::empty_node()
 	}
@@ -832,10 +822,6 @@ impl<H: Hasher> NodeCodec<H> for ReferenceNodeCodecNoExt {
 				})
 			}
 		}
-	}
-
-	fn try_decode_hash(data: &[u8]) -> Option<<H as Hasher>::Out> {
-		<ReferenceNodeCodec as NodeCodec<H>>::try_decode_hash(data)
 	}
 
 	fn is_empty_node(data: &[u8]) -> bool {

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -123,6 +123,7 @@ pub enum TrieError<T, E> {
 	ValueAtIncompleteKey(Vec<u8>, u8),
 	/// Corrupt Trie item
 	DecoderError(T, E),
+	InvalidHash(T, Vec<u8>),
 }
 
 #[cfg(feature = "std")]
@@ -138,6 +139,12 @@ impl<T, E> fmt::Display for TrieError<T, E> where T: MaybeDebug, E: MaybeDebug {
 			TrieError::DecoderError(ref hash, ref decoder_err) => {
 				write!(f, "Decoding failed for hash {:?}; err: {:?}", hash, decoder_err)
 			}
+			TrieError::InvalidHash(ref hash, ref data) =>
+				write!(
+					f,
+					"Encoded node {:?} contains invalid hash reference with length: {}",
+					hash, data.len()
+				),
 		}
 	}
 }
@@ -150,6 +157,7 @@ impl<T, E> Error for TrieError<T, E> where T: fmt::Debug, E: Error {
 			TrieError::IncompleteDatabase(_) => "Incomplete database",
 			TrieError::ValueAtIncompleteKey(_, _) => "Value at incomplete key",
 			TrieError::DecoderError(_, ref err) => err.description(),
+			TrieError::InvalidHash(_, _) => "Encoded node contains invalid hash reference",
 		}
 	}
 }

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -423,7 +423,7 @@ pub trait TrieLayout {
 	/// Hasher to use for this trie.
 	type Hash: Hasher;
 	/// Codec to use (needs to match hasher and nibble ops).
-	type Codec: NodeCodec<Self::Hash>;
+	type Codec: NodeCodec<HashOut=<Self::Hash as Hasher>::Out>;
 }
 
 /// This traits associates a trie definition with prefered methods.
@@ -485,6 +485,4 @@ pub trait TrieConfiguration: Sized + TrieLayout {
 /// Alias accessor to hasher hash output type from a `TrieLayout`.
 pub type TrieHash<L> = <<L as TrieLayout>::Hash as Hasher>::Out;
 /// Alias accessor to `NodeCodec` associated `Error` type from a `TrieLayout`.
-pub type CError<L> = <
-	<L as TrieLayout>::Codec as NodeCodec<<L as TrieLayout>::Hash>
->::Error;
+pub type CError<L> = <<L as TrieLayout>::Codec as NodeCodec>::Error;

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -189,7 +189,7 @@ pub struct OwnedNode<D: Borrow<[u8]>> {
 
 impl<D: Borrow<[u8]>> OwnedNode<D> {
 	/// Construct an `OwnedNode` by decoding an owned data source according to some codec.
-	pub fn new<H: Hasher, C: NodeCodec<H>>(data: D) -> Result<Self, C::Error> {
+	pub fn new<C: NodeCodec>(data: D) -> Result<Self, C::Error> {
 		let plan = C::decode_plan(data.borrow())?;
 		Ok(OwnedNode { data, plan })
 	}

--- a/trie-db/src/node_codec.rs
+++ b/trie-db/src/node_codec.rs
@@ -59,9 +59,6 @@ pub trait NodeCodec<H: Hasher>: Sized {
 		Ok(Self::decode_plan(data)?.build(data))
 	}
 
-	/// Decode bytes to the `Hasher`s output type. Returns `None` on failure.
-	fn try_decode_hash(data: &[u8]) -> Option<H::Out>;
-
 	/// Check if the provided bytes correspond to the codecs "empty" node.
 	fn is_empty_node(data: &[u8]) -> bool;
 

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -121,7 +121,7 @@ where
 			}
 			NodeHandle::Inline(data) => (None, DBValue::from_slice(data)),
 		};
-		let owned_node = OwnedNode::new::<L::Hash, L::Codec>(node_data)
+		let owned_node = OwnedNode::new::<L::Codec>(node_data)
 			.map_err(|e| Box::new(TrieError::DecoderError(node_hash.unwrap_or(parent_hash), e)))?;
 		Ok((owned_node, node_hash))
 	}

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -106,8 +106,8 @@ where
 		storage: &mut NodeStorage<H::Out>
 	) -> Result<NodeHandle<H::Out>, H::Out, C::Error>
 	where
-		C: NodeCodec<H>,
-		H: Hasher<Out = O>,
+		C: NodeCodec<HashOut=O>,
+		H: Hasher<Out=O>,
 	{
 		let handle = match child {
 			EncodedNodeHandle::Hash(data) => {
@@ -131,7 +131,7 @@ where
 		storage: &'b mut NodeStorage<H::Out>,
 	) -> Result<Self, H::Out, C::Error>
 		where
-			C: NodeCodec<H>, H: Hasher<Out = O>,
+			C: NodeCodec<HashOut = O>, H: Hasher<Out = O>,
 	{
 		let encoded_node = C::decode(data)
 			.map_err(|e| Box::new(TrieError::DecoderError(node_hash, e)))?;
@@ -183,7 +183,7 @@ where
 	// TODO: parallelize
 	fn into_encoded<F, C, H>(self, mut child_cb: F) -> Vec<u8>
 	where
-		C: NodeCodec<H>,
+		C: NodeCodec<HashOut=O>,
 		F: FnMut(NodeHandle<H::Out>, Option<&NibbleSlice>, Option<u8>) -> ChildReference<H::Out>,
 		H: Hasher<Out = O>,
 	{
@@ -1618,7 +1618,7 @@ mod tests {
 	}
 
 	fn reference_hashed_null_node() -> <KeccakHasher as Hasher>::Out {
-		<ReferenceNodeCodec	as NodeCodec<KeccakHasher>>::hashed_null_node()
+		<ReferenceNodeCodec<KeccakHasher> as NodeCodec>::hashed_null_node()
 	}
 
 	#[test]

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -16,7 +16,7 @@
 
 use super::{Result, TrieError, TrieMut, TrieLayout, TrieHash, CError};
 use super::lookup::Lookup;
-use super::node::Node as EncodedNode;
+use super::node::{NodeHandle as EncodedNodeHandle, Node as EncodedNode, decode_hash};
 use node_codec::NodeCodec;
 use super::{DBValue, node::NodeKey};
 
@@ -100,72 +100,84 @@ where
 {
 	// load an inline node into memory or get the hash to do the lookup later.
 	fn inline_or_hash<C, H>(
-		node: &[u8],
+		parent_hash: H::Out,
+		child: EncodedNodeHandle,
 		db: &dyn HashDB<H, DBValue>,
 		storage: &mut NodeStorage<H::Out>
-	) -> NodeHandle<H::Out>
+	) -> Result<NodeHandle<H::Out>, H::Out, C::Error>
 	where
 		C: NodeCodec<H>,
 		H: Hasher<Out = O>,
 	{
-		C::try_decode_hash(&node)
-			.map(NodeHandle::Hash)
-			.unwrap_or_else(|| {
-				let child = Node::from_encoded::<C, H>(node, db, storage);
+		let handle = match child {
+			EncodedNodeHandle::Hash(data) => {
+				let hash = decode_hash::<H>(data)
+					.ok_or_else(|| Box::new(TrieError::InvalidHash(parent_hash, data.to_vec())))?;
+				NodeHandle::Hash(hash)
+			},
+			EncodedNodeHandle::Inline(data) => {
+				let child = Node::from_encoded::<C, H>(parent_hash, data, db, storage)?;
 				NodeHandle::InMemory(storage.alloc(Stored::New(child)))
-			})
+			},
+		};
+		Ok(handle)
 	}
 
 	// Decode a node from encoded bytes.
 	fn from_encoded<'a, 'b, C, H>(
+		node_hash: H::Out,
 		data: &'a[u8],
 		db: &dyn HashDB<H, DBValue>,
 		storage: &'b mut NodeStorage<H::Out>,
-	) -> Self
+	) -> Result<Self, H::Out, C::Error>
 		where
 			C: NodeCodec<H>, H: Hasher<Out = O>,
 	{
-		match C::decode(data).unwrap_or(EncodedNode::Empty) {
+		let encoded_node = C::decode(data)
+			.map_err(|e| Box::new(TrieError::DecoderError(node_hash, e)))?;
+		let node = match encoded_node {
 			EncodedNode::Empty => Node::Empty,
 			EncodedNode::Leaf(k, v) => Node::Leaf(k.into(), DBValue::from_slice(&v)),
 			EncodedNode::Extension(key, cb) => {
 				Node::Extension(
 					key.into(),
-					Self::inline_or_hash::<C, H>(cb, db, storage))
-				},
+					Self::inline_or_hash::<C, H>(node_hash, cb, db, storage)?
+				)
+			},
 			EncodedNode::Branch(encoded_children, val) => {
-				let mut child = |i:usize| {
-					encoded_children[i].map(|data|
-						Self::inline_or_hash::<C, H>(data, db, storage)
-					)
+				let mut child = |i:usize| match encoded_children[i] {
+					Some(child) => Self::inline_or_hash::<C, H>(node_hash, child, db, storage)
+						.map(Some),
+					None => Ok(None),
 				};
 
 				let children = Box::new([
-					child(0), child(1), child(2), child(3),
-					child(4), child(5), child(6), child(7),
-					child(8), child(9), child(10), child(11),
-					child(12), child(13), child(14), child(15),
+					child(0)?, child(1)?, child(2)?, child(3)?,
+					child(4)?, child(5)?, child(6)?, child(7)?,
+					child(8)?, child(9)?, child(10)?, child(11)?,
+					child(12)?, child(13)?, child(14)?, child(15)?,
 				]);
 
 				Node::Branch(children, val.map(DBValue::from_slice))
 			},
 			EncodedNode::NibbledBranch(k, encoded_children, val) => {
-				let mut child = |i:usize| {
-					encoded_children[i].map(|data|
-						Self::inline_or_hash::<C, H>(data, db, storage)
-					)
+				let mut child = |i:usize| match encoded_children[i] {
+					Some(child) => Self::inline_or_hash::<C, H>(node_hash, child, db, storage)
+						.map(Some),
+					None => Ok(None),
 				};
 
 				let children = Box::new([
-					child(0), child(1), child(2), child(3),
-					child(4), child(5), child(6), child(7),
-					child(8), child(9), child(10), child(11),
-					child(12), child(13), child(14), child(15),
+					child(0)?, child(1)?, child(2)?, child(3)?,
+					child(4)?, child(5)?, child(6)?, child(7)?,
+					child(8)?, child(9)?, child(10)?, child(11)?,
+					child(12)?, child(13)?, child(14)?, child(15)?,
 				]);
 
 				Node::NibbledBranch(k.into(), children, val.map(DBValue::from_slice))
 			},
-		}
+		};
+		Ok(node)
 	}
 
 	// TODO: parallelize
@@ -428,10 +440,11 @@ where
 		let node_encoded = self.db.get(&hash, key)
 			.ok_or_else(|| Box::new(TrieError::IncompleteDatabase(hash)))?;
 		let node = Node::from_encoded::<L::Codec, L::Hash>(
+			hash,
 			&node_encoded,
 			&*self.db,
 			&mut self.storage
-		);
+		)?;
 		Ok(self.storage.alloc(Stored::Cached(node, hash)))
 	}
 


### PR DESCRIPTION
Currently, branch and extension nodes just have a byte slice reference to the child nodes and one uses the `NodeCodec::try_decode_hash` method to determine whether it is a hash or an inline node reference. Instead, we make this an explicit part of the decoded Node structure to simply code and make the codec more flexible. For example, we can stop encoding the length of the hashes inside branch nodes and instead use another bitfield inside branch nodes to indicate whether each child is a hash or inline reference, which should save space.

This is another breaking change to NodeCodec building on #34.