### PR TITLE
Bump trie-db and reference-trie crates to 0.16.0.

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -11,6 +11,8 @@ heapsize = { version = "0.4", optional = true }
 parity-util-mem = { version = "0.2", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.6.3", default-features = false, features = [ "ahash" ] }
+# There's a compilation error with ahash-0.2.17, which is permitted by the 0.2.11 constraint in hashbrown.
+ahash = "0.2.18"
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2"}

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -11,7 +11,7 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.15.2"}
+trie-db = { path = "../../trie-db", default-features = false, version = "0.16.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.15.2" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.15.2" }
 trie-root = { path = "../../trie-root", version = "0.15.2" }
-trie-db = { path = "../../trie-db", version = "0.15.2" }
+trie-db = { path = "../../trie-db", version = "0.16.0" }
 criterion = "0.2.8"
 parity-scale-codec = { version = "1.0.3" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -20,7 +20,7 @@ trie-root = { path = "../trie-root", version = "0.15.2"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.15.2" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.16.0" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 parity-codec = "3.0"

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -15,7 +15,7 @@ hex-literal = "0.1"
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.15.2" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.16.0" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Bump from 0.15 to 0.16 after breaking changes to trie-db crate.