### PR TITLE
Create TrieDBBrokenIterator replicating version <0.16 iterator bug.

### DIFF
--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -33,8 +33,8 @@ use std::borrow::Borrow;
 use keccak_hasher::KeccakHasher;
 
 pub use trie_db::{
-	Trie, TrieError, TrieMut, TrieIterator, TrieDBNodeIterator, NibbleSlice, NibbleVec, Recorder,
-	NodeCodec,
+	Trie, TrieError, TrieMut, TrieIterator, TrieDBBrokenIterator, TrieDBNodeIterator,
+	NibbleSlice, NibbleVec, Recorder, NodeCodec,
 };
 pub use trie_db::{Record, TrieLayout, TrieConfiguration, nibble_ops};
 pub use trie_root::TrieStream;

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -87,7 +87,7 @@ mod nibble;
 mod node_codec;
 
 pub use hash_db::{HashDB, HashDBRef, Hasher};
-pub use self::triedb::{TrieDB, TrieDBIterator};
+pub use self::triedb::{TrieDB, TrieDBBrokenIterator, TrieDBIterator};
 pub use self::triedbmut::{TrieDBMut, ChildReference};
 pub use self::sectriedbmut::SecTrieDBMut;
 pub use self::sectriedb::SecTrieDB;


### PR DESCRIPTION
In versions <0.16.0 of trie-db, a bug in `TrieDBIterator` would cause `seek` to position the cursor incorrectly in some cases. In particular, the cursor would be positioned at the beginning of a branch or extension node even if the key parameter follows it. This bug has become part of the consensus logic on certain deployed blockchains including Kusama.

This is part of the solution for fixing the storage root mismatch bug on Kusama.