### PR TITLE
Replace ElasticArray with SmallVec

### DIFF
--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -72,7 +72,7 @@ pub trait PlainDB<K, V>: Send + Sync + AsPlainDB<K, V> {
 	/// hash is not known.
 	fn get(&self, key: &K) -> Option<V>;
 
-	/// Check for the existance of a hash-key.
+	/// Check for the existence of a hash-key.
 	fn contains(&self, key: &K) -> bool;
 
 	/// Insert a datum item into the DB. Insertions are counted and the equivalent
@@ -113,7 +113,7 @@ pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
 	/// hash is not known.
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T>;
 
-	/// Check for the existance of a hash-key.
+	/// Check for the existence of a hash-key.
 	fn contains(&self, key: &H::Out, prefix: Prefix) -> bool;
 
 	/// Insert a datum item into the DB and return the datum's hash for a later lookup. Insertions

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 [dependencies]
 log = "0.4"
 rand = { version = "0.6", default-features = false }
-elastic-array = { version = "0.10", default-features = false }
 smallvec = "1.0.0"
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.6.3", default-features = false }
@@ -30,7 +29,6 @@ parity-codec-derive = "3.0"
 [features]
 default = ["std"]
 std = [
-  "elastic-array/std",
   "hash-db/std",
   "rand/std",
 ]

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 log = "0.4"
 rand = { version = "0.6", default-features = false }
 elastic-array = { version = "0.10", default-features = false }
+smallvec = "1.0.0"
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.6.3", default-features = false }
 

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -119,8 +119,7 @@ where
 					let aux_hash = L::Hash::hash(&hash);
 					(
 						self.trie.db().get(&aux_hash, Default::default())
-							.expect("Missing fatdb hash")
-							.into_vec(),
+							.expect("Missing fatdb hash"),
 						value,
 					)
 				})
@@ -144,9 +143,10 @@ mod test {
 			t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
 		}
 		let t = RefFatDB::new(&memdb, &root).unwrap();
-		assert_eq!(t.get(&[0x01u8, 0x23]).unwrap().unwrap(), DBValue::from_slice(&[0x01u8, 0x23]));
+		assert_eq!(t.get(&[0x01u8, 0x23]).unwrap().unwrap(), vec![0x01u8, 0x23]);
 		assert_eq!(
 			t.iter().unwrap().map(Result::unwrap).collect::<Vec<_>>(),
-			vec![(vec![0x01u8, 0x23], DBValue::from_slice(&[0x01u8, 0x23] as &[u8]))]);
+			vec![(vec![0x01u8, 0x23], vec![0x01u8, 0x23])]
+		);
 	}
 }

--- a/trie-db/src/fatdbmut.rs
+++ b/trie-db/src/fatdbmut.rs
@@ -88,7 +88,7 @@ where
 		// insert if it doesn't exist.
 		if out.is_none() {
 			let aux_hash = L::Hash::hash(hash.as_ref());
-			db.emplace(aux_hash, EMPTY_PREFIX, DBValue::from_slice(key));
+			db.emplace(aux_hash, EMPTY_PREFIX, key.to_vec());
 		}
 		Ok(out)
 	}
@@ -126,7 +126,7 @@ mod test {
 		let t = RefTrieDB::new(&memdb, &root).unwrap();
 		assert_eq!(
 			t.get(&KeccakHasher::hash(&[0x01u8, 0x23])),
-			Ok(Some(DBValue::from_slice(&[0x01u8, 0x23]))),
+			Ok(Some(vec![0x01u8, 0x23])),
 		);
 	}
 
@@ -140,8 +140,8 @@ mod test {
 		let aux_hash = KeccakHasher::hash(&key_hash);
 		let mut t = RefFatDBMut::new(&mut memdb, &mut root);
 		t.insert(&key, &val).unwrap();
-		assert_eq!(t.get(&key), Ok(Some(DBValue::from_slice(&val))));
-		assert_eq!(t.db().get(&aux_hash, EMPTY_PREFIX), Some(DBValue::from_slice(&key)));
+		assert_eq!(t.get(&key), Ok(Some(val.to_vec())));
+		assert_eq!(t.db().get(&aux_hash, EMPTY_PREFIX), Some(key.to_vec()));
 		t.remove(&key).unwrap();
 		assert_eq!(t.db().get(&aux_hash, EMPTY_PREFIX), None);
 	}

--- a/trie-db/src/iter_build.rs
+++ b/trie-db/src/iter_build.rs
@@ -521,7 +521,7 @@ mod test {
 			let key: &[u8]= &data[i].0;
 			let value: &[u8] = &data[i].1;
 			assert_eq!(k, key);
-			assert_eq!(v, value);
+			assert_eq!(v.as_ref(), value);
 		}
 		for (k, v) in data.into_iter() {
 			assert_eq!(&t.get(&k[..]).unwrap().unwrap()[..], &v[..]);
@@ -547,7 +547,7 @@ mod test {
 			let key: &[u8]= &data[i].0;
 			let value: &[u8] = &data[i].1;
 			assert_eq!(k, key);
-			assert_eq!(v, value);
+			assert_eq!(v.as_ref(), value);
 		}
 		for (k, v) in data.into_iter() {
 			assert_eq!(&t.get(&k[..]).unwrap().unwrap()[..], &v[..]);

--- a/trie-db/src/iter_build.rs
+++ b/trie-db/src/iter_build.rs
@@ -521,7 +521,7 @@ mod test {
 			let key: &[u8]= &data[i].0;
 			let value: &[u8] = &data[i].1;
 			assert_eq!(k, key);
-			assert_eq!(v.as_ref(), value);
+			assert_eq!(v, value);
 		}
 		for (k, v) in data.into_iter() {
 			assert_eq!(&t.get(&k[..]).unwrap().unwrap()[..], &v[..]);
@@ -547,7 +547,7 @@ mod test {
 			let key: &[u8]= &data[i].0;
 			let value: &[u8] = &data[i].1;
 			assert_eq!(k, key);
-			assert_eq!(v.as_ref(), value);
+			assert_eq!(v, value);
 		}
 		for (k, v) in data.into_iter() {
 			assert_eq!(&t.get(&k[..]).unwrap().unwrap()[..], &v[..]);

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -18,7 +18,6 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-extern crate elastic_array;
 extern crate smallvec;
 extern crate hash_db;
 extern crate rand;

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -19,6 +19,7 @@
 extern crate alloc;
 
 extern crate elastic_array;
+extern crate smallvec;
 extern crate hash_db;
 extern crate rand;
 #[macro_use]
@@ -106,7 +107,7 @@ pub use trie_codec::{decode_compact, encode_compact};
 #[cfg(feature = "std")]
 pub use iter_build::TrieRootPrint;
 
-pub type DBValue = elastic_array::ElasticArray128<u8>;
+pub type DBValue = smallvec::SmallVec<[u8; 128]>;
 
 /// Trie Errors.
 ///

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -107,7 +107,7 @@ pub use trie_codec::{decode_compact, encode_compact};
 pub use iter_build::TrieRootPrint;
 
 /// Database value
-pub type DBValue = smallvec::SmallVec<[u8; 128]>;
+pub type DBValue = Vec<u8>;
 
 /// Trie Errors.
 ///
@@ -191,7 +191,7 @@ pub trait Query<H: Hasher> {
 
 impl<'a, H: Hasher> Query<H> for &'a mut Recorder<H::Out> {
 	type Item = DBValue;
-	fn decode(self, value: &[u8]) -> DBValue { DBValue::from_slice(value) }
+	fn decode(self, value: &[u8]) -> DBValue { value.to_vec() }
 	fn record(&mut self, hash: &H::Out, data: &[u8], depth: u32) {
 		(&mut **self).record(hash, data, depth);
 	}
@@ -228,7 +228,7 @@ pub trait Trie<L: TrieLayout> {
 		&'a self,
 		key: &'key [u8],
 	) -> Result<Option<DBValue>, TrieHash<L>, CError<L>> where 'a: 'key {
-		self.get_with(key, DBValue::from_slice)
+		self.get_with(key, |v: &[u8]| v.to_vec() )
 	}
 
 	/// Search for the key with the given query parameter. See the docs of the `Query`
@@ -429,9 +429,9 @@ pub trait TrieLayout {
 	type Codec: NodeCodec<HashOut=<Self::Hash as Hasher>::Out>;
 }
 
-/// This traits associates a trie definition with prefered methods.
+/// This trait associates a trie definition with preferred methods.
 /// It also contains own default implementations and can be
-/// use to allow switching implementation.
+/// used to allow switching implementation.
 pub trait TrieConfiguration: Sized + TrieLayout {
 	/// Operation to build a trie db from its ordered iterator over its key/values.
 	fn trie_build<DB, I, A, B>(db: &mut DB, input: I) -> <Self::Hash as Hasher>::Out where

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -106,6 +106,7 @@ pub use trie_codec::{decode_compact, encode_compact};
 #[cfg(feature = "std")]
 pub use iter_build::TrieRootPrint;
 
+/// Database value
 pub type DBValue = smallvec::SmallVec<[u8; 128]>;
 
 /// Trie Errors.

--- a/trie-db/src/nibble/mod.rs
+++ b/trie-db/src/nibble/mod.rs
@@ -16,7 +16,7 @@
 
 mod nibblevec;
 mod nibbleslice;
-use elastic_array::ElasticArray36;
+use smallvec::SmallVec;
 use crate::node::NodeKey;
 use core_::cmp;
 
@@ -152,7 +152,7 @@ pub mod nibble_ops {
 #[cfg_attr(feature = "std", derive(Debug))]
 #[derive(Clone, PartialEq, Eq)]
 pub struct NibbleVec {
-	inner: ElasticArray36<u8>,
+	inner: SmallVec<[u8; 36]>,
 	len: usize,
 }
 

--- a/trie-db/src/nibble/mod.rs
+++ b/trie-db/src/nibble/mod.rs
@@ -16,7 +16,6 @@
 
 mod nibblevec;
 mod nibbleslice;
-use smallvec::SmallVec;
 use crate::node::NodeKey;
 use core_::cmp;
 
@@ -146,13 +145,16 @@ pub mod nibble_ops {
 
 }
 
+/// Backing storage for `NibbleVec`s.
+pub(crate) type BackingByteVec = smallvec::SmallVec<[u8; 36]>;
+
 /// Owning, nibble-oriented byte vector. Counterpart to `NibbleSlice`.
 /// Nibbles are always left aligned, so making a `NibbleVec` from
 /// a `NibbleSlice` can get costy.
 #[cfg_attr(feature = "std", derive(Debug))]
 #[derive(Clone, PartialEq, Eq)]
 pub struct NibbleVec {
-	inner: SmallVec<[u8; 36]>,
+	inner: BackingByteVec,
 	len: usize,
 }
 

--- a/trie-db/src/nibble/nibbleslice.rs
+++ b/trie-db/src/nibble/nibbleslice.rs
@@ -16,8 +16,7 @@
 
 use ::core_::cmp::*;
 use ::core_::fmt;
-use super::{nibble_ops, NibbleSlice, NibbleSliceIterator};
-use smallvec::SmallVec;
+use super::{nibble_ops, NibbleSlice, NibbleSliceIterator, BackingByteVec};
 use node::NodeKey;
 use node_codec::Partial;
 use hash_db::Prefix;
@@ -78,13 +77,13 @@ impl<'a> NibbleSlice<'a> {
 			let end = (self.offset + nb) / nibble_ops::NIBBLE_PER_BYTE;
 			(
 				self.offset % nibble_ops::NIBBLE_PER_BYTE,
-				SmallVec::<[u8; 36]>::from_slice(&self.data[start..end]),
+				BackingByteVec::from_slice(&self.data[start..end]),
 			)
 		} else {
 			// unaligned
 			let start = self.offset / nibble_ops::NIBBLE_PER_BYTE;
 			let end = (self.offset + nb) / nibble_ops::NIBBLE_PER_BYTE;
-			let ea = SmallVec::<[u8; 36]>::from_slice(&self.data[start..=end]);
+			let ea = BackingByteVec::from_slice(&self.data[start..=end]);
 			let ea_offset = self.offset % nibble_ops::NIBBLE_PER_BYTE;
 			let n_offset = nibble_ops::number_padding(nb);
 			let mut result = (ea_offset, ea);
@@ -229,7 +228,7 @@ impl<'a> NibbleSlice<'a> {
 	}
 
 	/// Owned version of a `Prefix` from a `left` method call.
-	pub fn left_owned(&'a self) -> (SmallVec<[u8; 36]>, Option<u8>) {
+	pub fn left_owned(&'a self) -> (BackingByteVec, Option<u8>) {
 		let (a, b) = self.left();
 		(a.into(), b)
 	}
@@ -285,8 +284,7 @@ impl<'a> fmt::Debug for NibbleSlice<'a> {
 
 #[cfg(test)]
 mod tests {
-	use crate::nibble::NibbleSlice;
-	use smallvec::SmallVec;
+	use crate::nibble::{NibbleSlice, BackingByteVec};
 	static D: &'static [u8;3] = &[0x01u8, 0x23, 0x45];
 
 	#[test]
@@ -329,16 +327,16 @@ mod tests {
 	#[test]
 	fn encoded_pre() {
 		let n = NibbleSlice::new(D);
-		assert_eq!(n.to_stored(), (0, SmallVec::<[u8; 36]>::from_slice(&[0x01, 0x23, 0x45])));
-		assert_eq!(n.mid(1).to_stored(), (1, SmallVec::<[u8; 36]>::from_slice(&[0x01, 0x23, 0x45])));
-		assert_eq!(n.mid(2).to_stored(), (0, SmallVec::<[u8; 36]>::from_slice(&[0x23, 0x45])));
-		assert_eq!(n.mid(3).to_stored(), (1, SmallVec::<[u8; 36]>::from_slice(&[0x23, 0x45])));
+		assert_eq!(n.to_stored(), (0, BackingByteVec::from_slice(&[0x01, 0x23, 0x45])));
+		assert_eq!(n.mid(1).to_stored(), (1, BackingByteVec::from_slice(&[0x01, 0x23, 0x45])));
+		assert_eq!(n.mid(2).to_stored(), (0, BackingByteVec::from_slice(&[0x23, 0x45])));
+		assert_eq!(n.mid(3).to_stored(), (1, BackingByteVec::from_slice(&[0x23, 0x45])));
 	}
 
 	#[test]
 	fn from_encoded_pre() {
 		let n = NibbleSlice::new(D);
-		let stored: SmallVec<[u8; 36]> = [0x01, 0x23, 0x45][..].into();
+		let stored: BackingByteVec = [0x01, 0x23, 0x45][..].into();
 		assert_eq!(n, NibbleSlice::from_stored(&(0, stored.clone())));
 		assert_eq!(n.mid(1), NibbleSlice::from_stored(&(1, stored)));
 	}

--- a/trie-db/src/nibble/nibblevec.rs
+++ b/trie-db/src/nibble/nibblevec.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //! An owning, nibble-oriented byte vector.
-use elastic_array::ElasticArray36;
+use smallvec::SmallVec;
 use nibble::NibbleSlice;
 use nibble::nibble_ops;
 use hash_db::Prefix;
@@ -30,7 +30,7 @@ impl NibbleVec {
 	/// Make a new `NibbleVec`.
 	pub fn new() -> Self {
 		NibbleVec {
-			inner: ElasticArray36::new(),
+			inner: SmallVec::<[u8; 36]>::new(),
 			len: 0,
 		}
 	}
@@ -138,7 +138,7 @@ impl NibbleVec {
 		}
 		let pad = self.inner.len() * nibble_ops::NIBBLE_PER_BYTE - self.len;
 		if pad == 0 {
-			self.inner.append_slice(&sl[..]);
+			self.inner.extend_from_slice(&sl[..]);
 		} else {
 			let kend = self.inner.len() - 1;
 			if sl.len() > 0 {

--- a/trie-db/src/nibble/nibblevec.rs
+++ b/trie-db/src/nibble/nibblevec.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 //! An owning, nibble-oriented byte vector.
-use smallvec::SmallVec;
-use nibble::NibbleSlice;
+
+use nibble::{NibbleSlice, BackingByteVec};
 use nibble::nibble_ops;
 use hash_db::Prefix;
 use node_codec::Partial;
@@ -30,7 +30,7 @@ impl NibbleVec {
 	/// Make a new `NibbleVec`.
 	pub fn new() -> Self {
 		NibbleVec {
-			inner: SmallVec::<[u8; 36]>::new(),
+			inner: BackingByteVec::new(),
 			len: 0,
 		}
 	}

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use elastic_array::ElasticArray36;
+use smallvec::SmallVec;
 use hash_db::Hasher;
 use nibble::NibbleSlice;
 use nibble::nibble_ops;
@@ -25,7 +25,7 @@ use alloc::vec::Vec;
 
 /// Partial node key type: offset and owned value of a nibbleslice.
 /// Offset is applied on first byte of array (bytes are right aligned).
-pub type NodeKey = (usize, ElasticArray36<u8>);
+pub type NodeKey = (usize, SmallVec<[u8; 36]>);
 
 /// A reference to a trie node which may be stored within another trie node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use smallvec::SmallVec;
 use hash_db::Hasher;
-use nibble::NibbleSlice;
+use nibble::{self, NibbleSlice};
 use nibble::nibble_ops;
 use node_codec::NodeCodec;
 
@@ -25,7 +24,7 @@ use alloc::vec::Vec;
 
 /// Partial node key type: offset and owned value of a nibbleslice.
 /// Offset is applied on first byte of array (bytes are right aligned).
-pub type NodeKey = (usize, SmallVec<[u8; 36]>);
+pub type NodeKey = (usize, nibble::BackingByteVec);
 
 /// A reference to a trie node which may be stored within another trie node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -102,6 +102,6 @@ mod test {
 			t.insert(&KeccakHasher::hash(&[0x01u8, 0x23]), &[0x01u8, 0x23]).unwrap();
 		}
 		let t = RefSecTrieDB::new(&db, &root).unwrap();
-		assert_eq!(t.get(&[0x01u8, 0x23]).unwrap().unwrap(), DBValue::from_slice(&[0x01u8, 0x23]));
+		assert_eq!(t.get(&[0x01u8, 0x23]).unwrap().unwrap(), vec![0x01u8, 0x23]);
 	}
 }

--- a/trie-db/src/sectriedbmut.rs
+++ b/trie-db/src/sectriedbmut.rs
@@ -107,7 +107,7 @@ mod test {
 		let t = RefTrieDB::new(&memdb, &root).unwrap();
 		assert_eq!(
 			t.get(&KeccakHasher::hash(&[0x01u8, 0x23])).unwrap().unwrap(),
-			DBValue::from_slice(&[0x01u8, 0x23]),
+			vec![0x01u8, 0x23],
 		);
 	}
 }

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -56,7 +56,7 @@ use alloc::vec::Vec;
 ///   RefTrieDBMut::new(&mut memdb, &mut root).insert(b"foo", b"bar").unwrap();
 ///   let t = RefTrieDB::new(&memdb, &root).unwrap();
 ///   assert!(t.contains(b"foo").unwrap());
-///   assert_eq!(t.get(b"foo").unwrap().unwrap(), DBValue::from_slice(b"bar"));
+///   assert_eq!(t.get(b"foo").unwrap().unwrap(), b"bar".to_vec());
 /// }
 /// ```
 pub struct TrieDB<'db, L>
@@ -119,7 +119,7 @@ where
 
 				(Some(node_hash), node_data)
 			}
-			NodeHandle::Inline(data) => (None, DBValue::from_slice(data)),
+			NodeHandle::Inline(data) => (None, data.to_vec()),
 		};
 		let owned_node = OwnedNode::new::<L::Codec>(node_data)
 			.map_err(|e| Box::new(TrieError::DecoderError(node_hash.unwrap_or(parent_hash), e)))?;
@@ -320,7 +320,7 @@ impl<'a, L: TrieLayout> Iterator for TrieDBIterator<'a, L> {
 								TrieError::ValueAtIncompleteKey(key, extra_nibble)
 							)));
 						}
-						return Some(Ok((key, DBValue::from_slice(value))));
+						return Some(Ok((key, value.to_vec())));
 					}
 				},
 				Err(err) => return Some(Err(err)),
@@ -417,7 +417,7 @@ mod tests {
 			iter.next().unwrap().unwrap(),
 			(
 				hex!("0103000000000000000464").to_vec(),
-				DBValue::from_slice(&hex!("fffffffffe")[..]),
+				hex!("fffffffffe").to_vec(),
 			)
 		);
 		iter.seek(&hex!("00")[..]).unwrap();
@@ -458,7 +458,7 @@ mod tests {
 		let mut iter = t.iter().unwrap();
 		assert_eq!(
 			iter.next().unwrap().unwrap(),
-			(hex!("0103000000000000000464").to_vec(), DBValue::from_slice(&hex!("fffffffffe")[..]))
+			(hex!("0103000000000000000464").to_vec(), hex!("fffffffffe").to_vec())
 		);
 		iter.seek(&hex!("00")[..]).unwrap();
 		assert_eq!(
@@ -476,10 +476,10 @@ mod tests {
 	#[test]
 	fn iterator() {
 		let d = vec![
-			DBValue::from_slice(b"A"),
-			DBValue::from_slice(b"AA"),
-			DBValue::from_slice(b"AB"),
-			DBValue::from_slice(b"B"),
+			b"A".to_vec(),
+			b"AA".to_vec(),
+			b"AB".to_vec(),
+			b"B".to_vec(),
 		];
 
 		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
@@ -494,7 +494,7 @@ mod tests {
 		let t = RefTrieDB::new(&memdb, &root).unwrap();
 		assert_eq!(
 			d.iter()
-				.map(|i| i.clone().into_vec())
+				.map(|i| i.clone())
 				.collect::<Vec<_>>(),
 			t.iter()
 				.unwrap()
@@ -507,10 +507,10 @@ mod tests {
 	#[test]
 	fn iterator_without_extension() {
 		let d = vec![
-			DBValue::from_slice(b"A"),
-			DBValue::from_slice(b"AA"),
-			DBValue::from_slice(b"AB"),
-			DBValue::from_slice(b"B"),
+			b"A".to_vec(),
+			b"AA".to_vec(),
+			b"AB".to_vec(),
+			b"B".to_vec(),
 		];
 
 		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
@@ -524,7 +524,7 @@ mod tests {
 
 		let t = RefTrieDBNoExt::new(&memdb, &root).unwrap();
 		assert_eq!(
-			d.iter().map(|i| i.clone().into_vec()).collect::<Vec<_>>(),
+			d.iter().map(|i| i.clone()).collect::<Vec<_>>(),
 			t.iter().unwrap().map(|x| x.unwrap().0).collect::<Vec<_>>(),
 		);
 		assert_eq!(d, t.iter().unwrap().map(|x| x.unwrap().1).collect::<Vec<_>>());
@@ -533,10 +533,10 @@ mod tests {
 	#[test]
 	fn iterator_seek() {
 		let d = vec![
-			DBValue::from_slice(b"A"),
-			DBValue::from_slice(b"AA"),
-			DBValue::from_slice(b"AB"),
-			DBValue::from_slice(b"B"),
+			b"A".to_vec(),
+			b"AA".to_vec(),
+			b"AB".to_vec(),
+			b"B".to_vec(),
 		];
 
 		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();
@@ -550,7 +550,7 @@ mod tests {
 
 		let t = RefTrieDBNoExt::new(&memdb, &root).unwrap();
 		let mut iter = t.iter().unwrap();
-		assert_eq!(iter.next().unwrap().unwrap(), (b"A".to_vec(), DBValue::from_slice(b"A")));
+		assert_eq!(iter.next().unwrap().unwrap(), (b"A".to_vec(), b"A".to_vec()));
 		iter.seek(b"!").unwrap();
 		assert_eq!(d, iter.map(|x| x.unwrap().1).collect::<Vec<_>>());
 		let mut iter = t.iter().unwrap();
@@ -611,10 +611,10 @@ mod tests {
 	#[test]
 	fn debug_output_supports_pretty_print() {
 		let d = vec![
-			DBValue::from_slice(b"A"),
-			DBValue::from_slice(b"AA"),
-			DBValue::from_slice(b"AB"),
-			DBValue::from_slice(b"B"),
+			b"A".to_vec(),
+			b"AA".to_vec(),
+			b"AB".to_vec(),
+			b"B".to_vec(),
 		];
 
 		let mut memdb = MemoryDB::<KeccakHasher, PrefixedKey<_>, DBValue>::default();

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -21,8 +21,7 @@ use node_codec::NodeCodec;
 use super::{DBValue, node::NodeKey};
 
 use hash_db::{HashDB, Hasher, Prefix, EMPTY_PREFIX};
-use nibble::{NibbleVec, NibbleSlice, nibble_ops};
-use smallvec::SmallVec;
+use nibble::{NibbleVec, NibbleSlice, nibble_ops, BackingByteVec};
 use ::core_::convert::TryFrom;
 use ::core_::mem;
 use ::core_::ops::Index;
@@ -406,7 +405,7 @@ where
 	db: &'a mut dyn HashDB<L::Hash, DBValue>,
 	root: &'a mut TrieHash<L>,
 	root_handle: NodeHandle<TrieHash<L>>,
-	death_row: HashSet<(TrieHash<L>, (SmallVec<[u8; 36]>, Option<u8>))>,
+	death_row: HashSet<(TrieHash<L>, (BackingByteVec, Option<u8>))>,
 	/// The number of hash operations this trie has performed.
 	/// Note that none are performed until changes are committed.
 	hash_count: usize,
@@ -1236,7 +1235,7 @@ where
 						let (start, alloc_start, prefix_end) = match key2.left() {
 							(start, None) => (start, None, Some(nibble_ops::push_at_left(0, a, 0))),
 							(start, Some(v)) => {
-								let mut so: SmallVec<[u8; 36]> = start.into();
+								let mut so: BackingByteVec = start.into();
 								so.push(nibble_ops::pad_left(v) | a);
 								(start, Some(so), None)
 							},
@@ -1310,7 +1309,7 @@ where
 				let (start, alloc_start, prefix_end) = match key2.left() {
 					(start, None) => (start, None, Some(nibble_ops::push_at_left(0, last, 0))),
 					(start, Some(v)) => {
-						let mut so: SmallVec<[u8; 36]> = start.into();
+						let mut so: BackingByteVec = start.into();
 						// Complete last byte with `last`.
 						so.push(nibble_ops::pad_left(v) | last);
 						(start, Some(so), None)
@@ -1601,9 +1600,9 @@ mod tests {
 	use memory_db::{MemoryDB, PrefixedKey};
 	use hash_db::{Hasher, HashDB};
 	use keccak_hasher::KeccakHasher;
-	use smallvec::SmallVec;
 	use reference_trie::{RefTrieDBMutNoExt, RefTrieDBMut, TrieMut, NodeCodec,
 		ReferenceNodeCodec, reference_trie_root, reference_trie_root_no_extension};
+	use nibble::BackingByteVec;
 
 	fn populate_trie<'db>(
 		db: &'db mut dyn HashDB<KeccakHasher, DBValue>,
@@ -2056,9 +2055,9 @@ mod tests {
 
 	#[test]
 	fn combine_test() {
-		let a: SmallVec<[u8; 36]> = [0x12, 0x34][..].into();
+		let a: BackingByteVec = [0x12, 0x34][..].into();
 		let b: &[u8] = [0x56, 0x78][..].into();
-		let test_comb = |a: (_, &SmallVec<_>), b, c| {
+		let test_comb = |a: (_, &BackingByteVec), b, c| {
 			let mut a = (a.0, a.1.clone());
 			super::combine_key(&mut a, b);
 			assert_eq!((a.0, &a.1[..]), c);


### PR DESCRIPTION
The `elastic-array` crate is a fine piece of software but it'd be good to prefer crates that are commonly used in the ecosystem and likely to be well maintained. `smallvec` is at `v1.0` and generally well-regarded.

Unfortunately as `DBValue` is part of the public API of `trie-db`, this is a breaking change so changing this implies annoying busy-work in consuming code.