### PR TITLE
Prepare versioning for 0.18 crates (no elastic array)

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.15.3"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-parity-util-mem = { version = "0.2", default-features = false }
+parity-util-mem = { version = "0.2", default-features = false } # TODO this requires update to latest version
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.6.3", default-features = false, features = [ "ahash" ] }
 # There's a compilation error with ahash-0.2.17, which is permitted by the 0.2.11 constraint in hashbrown.

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.16.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -11,12 +11,12 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.16.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.18.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.15.2" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.17.0" }
+trie-bench = { path = "../trie-bench", version = "0.18.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -11,8 +11,8 @@ edition = "2018"
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
-memory-db = { path = "../../memory-db", version = "0.15.2" }
+memory-db = { path = "../../memory-db", version = "0.18.0" }
 trie-root = { path = "../../trie-root", version = "0.15.2" }
-trie-db = { path = "../../trie-db", version = "0.16.0" }
+trie-db = { path = "../../trie-db", version = "0.18.0" }
 criterion = "0.2.8"
 parity-scale-codec = { version = "1.0.3" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.16.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -15,12 +15,12 @@ hashbrown = { version = "0.6.3", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.15.2" }
+memory-db = { path = "../memory-db", version = "0.18.0" }
 trie-root = { path = "../trie-root", version = "0.15.2"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.16.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.18.0" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 parity-codec = "3.0"

--- a/trie-db/fuzz/Cargo.toml
+++ b/trie-db/fuzz/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-memory-db = { path = "../../memory-db", version = "0.15.2" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.16.0" }
+memory-db = { path = "../../memory-db", version = "0.18.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.18.0" }
 keccak-hasher = { path = "../../test-support/keccak-hasher", version = "0.15.2" }
 
 [dependencies.trie-db]

--- a/trie-db/src/fatdbmut.rs
+++ b/trie-db/src/fatdbmut.rs
@@ -109,7 +109,6 @@ where
 
 #[cfg(test)]
 mod test {
-	use DBValue;
 	use memory_db::{MemoryDB, HashKey};
 	use hash_db::{Hasher, EMPTY_PREFIX};
 	use keccak_hasher::KeccakHasher;

--- a/trie-db/src/iter_build.rs
+++ b/trie-db/src/iter_build.rs
@@ -367,7 +367,7 @@ impl<'a, H: Hasher, V, DB: HashDB<H, V>> ProcessEncodedNode<<H as Hasher>::Out>
 pub struct TrieRoot<H, HO> {
 	/// The resulting root.
 	pub root: Option<HO>,
-	_ph: PhantomData<(H)>,
+	_ph: PhantomData<H>,
 }
 
 impl<H, HO> Default for TrieRoot<H, HO> {
@@ -402,7 +402,7 @@ impl<H: Hasher> ProcessEncodedNode<<H as Hasher>::Out> for TrieRoot<H, <H as Has
 pub struct TrieRootUnhashed<H> {
 	/// The resulting encoded root.
 	pub root: Option<Vec<u8>>,
-	_ph: PhantomData<(H)>,
+	_ph: PhantomData<H>,
 }
 
 impl<H> Default for TrieRootUnhashed<H> {
@@ -417,7 +417,7 @@ impl<H> Default for TrieRootUnhashed<H> {
 pub struct TrieRootPrint<H, HO> {
 	/// The resulting root.
 	pub root: Option<HO>,
-	_ph: PhantomData<(H)>,
+	_ph: PhantomData<H>,
 }
 
 #[cfg(feature = "std")]

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -225,7 +225,7 @@ where
 						.finish()
 				},
 				Node::NibbledBranch(slice, nodes, value) => {
-					let nodes: Vec<TrieAwareDebugNode<L>> = nodes.into_iter()
+					let nodes: Vec<TrieAwareDebugNode<L>> = nodes.iter()
 						.enumerate()
 						.filter_map(|(i, n)| n.map(|n| (i, n)))
 						.map(|(i, n)| TrieAwareDebugNode {

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -15,7 +15,7 @@ hex-literal = "0.1"
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.16.0" }
+reference-trie = { path = "../test-support/reference-trie", version = "0.18.0" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This is versioning change for elastic array removal, (I did not include #39 (only one review) but it can be release in a later patch version).

**It still requires that new version of parity-util-mem get published first (see TODO in memorydb Cargo.toml).**

Note that it seems like some crate do not have to move to 0.18 (because hashdb is untouched from this change).