### PR TITLE
Implement `Debug` for `TrieError` in `no_std`

### DIFF
--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -114,8 +114,7 @@ pub type DBValue = Vec<u8>;
 ///
 /// These borrow the data within them to avoid excessive copying on every
 /// trie operation.
-#[derive(PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum TrieError<T, E> {
 	/// Attempted to create a trie with a state root not in the DB.
 	InvalidStateRoot(T),


### PR DESCRIPTION
`TrieError` should implement `Debug` in `no_std` as well. The compiler
can optimize it away if not required, but it enables us to use `expect`
in `no_std`. This is helpful for Cumulus, where I currently have a
custom `unwrap_trie_error` function with panics.