### PR TITLE
Fixes no_std builds for memory-db and trie-db.

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -16,6 +16,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use hash_db::{HashDB, HashDBRef, PlainDB, PlainDBRef, Hasher as KeyHasher,
 	AsHashDB, AsPlainDB, Prefix};
 use parity_util_mem::{MallocSizeOf, MallocSizeOfOps};

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/src/proof/generate.rs
+++ b/trie-db/src/proof/generate.rs
@@ -15,7 +15,7 @@
 //! Generation of compact proofs for Merkle-Patricia tries.
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core_::convert::TryInto;
 use core_::marker::PhantomData;
 use core_::ops::Range;


### PR DESCRIPTION
The `no_std` builds look broken:

 * The broken build in `memory-db` may be reproduced with `cargo build --no-default-features`
 * The broken build in `trie-db` for some reason is only triggered while building substrate.

Probably this commit should bump the patchversion to `0.19.2`?