### PR TITLE
Upgrade to rand 0.7

### DIFF
--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 log = "0.4"
-rand = { version = "0.6", default-features = false }
+rand = { version = "0.7", default-features = false }
 smallvec = "1.0.0"
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.6.3", default-features = false }


### PR DESCRIPTION
this should drop dependency on `rand_isaac` and alleviate possible cargo feature leaking to no-std binaries