### PR TITLE
trie-db: fix std feature leaking

### DIFF
--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -21,7 +21,7 @@ trie-root = { path = "../trie-root", version = "0.15.2"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", version = "0.19.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.19.0" }
 hex-literal = "0.1"
 criterion = "0.2.8"
 parity-codec = "3.0"


### PR DESCRIPTION
`cd trie-db && cargo check --no-default-features`