### PR TITLE
Fs update trie bench and reference trie

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -11,12 +11,12 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.19.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.19.2" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.15.2" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.18.0" }
+trie-bench = { path = "../trie-bench", version = "0.18.1" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -11,8 +11,8 @@ edition = "2018"
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
-memory-db = { path = "../../memory-db", version = "0.18.0" }
+memory-db = { path = "../../memory-db", version = "0.18.1" }
 trie-root = { path = "../../trie-root", version = "0.15.2" }
-trie-db = { path = "../../trie-db", version = "0.19.0" }
+trie-db = { path = "../../trie-db", version = "0.19.2" }
 criterion = "0.2.8"
 parity-scale-codec = { version = "1.0.3" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -16,7 +16,7 @@ rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.18.0" }
+memory-db = { path = "../memory-db", version = "0.18.1" }
 trie-root = { path = "../trie-root", version = "0.15.2"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 log = "0.4"
-rand = { version = "0.7", default-features = false }
+rand = { version = "0.7", default-features = false, features = [ "small_rng" ] }
 smallvec = "1.0.0"
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.6.3", default-features = false }

--- a/trie-db/fuzz/Cargo.toml
+++ b/trie-db/fuzz/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-memory-db = { path = "../../memory-db", version = "0.18.0" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.18.0" }
+memory-db = { path = "../../memory-db", version = "0.18.1" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.18.1" }
 keccak-hasher = { path = "../../test-support/keccak-hasher", version = "0.15.2" }
 
 [dependencies.trie-db]


### PR DESCRIPTION
1) Benches in `trie-db` look broken (running `cargo check --benches --all` seems to fail bc. a `small_rng` feature is not enabled for `rand`)
2) Update all depencencies on `trie-db` and `memory-db` to the latest ones.