### PR TITLE
trie-bench version 0.19.0

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -16,7 +16,7 @@ trie-root = { path = "../../trie-root", default-features = false, version = "0.1
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.18.0" }
+trie-bench = { path = "../trie-bench", version = "0.19.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.18.0" }
 trie-root = { path = "../../trie-root", version = "0.15.2" }
-trie-db = { path = "../../trie-db", version = "0.19.0" }
+trie-db = { path = "../../trie-db", version = "0.19.2" }
 criterion = "0.2.8"
 parity-scale-codec = { version = "1.0.3" }

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps a `trie-bench` version so paritytech/substrate#4646 hopefully builds