### PR TITLE
Update parity-util-mem

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-parity-util-mem = { version = "0.3", default-features = false }
+parity-util-mem = { version = "0.5.1", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.6.3", default-features = false, features = [ "ahash" ] }
 # There's a compilation error with ahash-0.2.17, which is permitted by the 0.2.11 constraint in hashbrown.


### PR DESCRIPTION
This will remove one extra dependency in substrate

```
[0] [11:01:30] ~/r/substrate cecton-cargo-update > cargo update -p parity-util-mem
error: There are multiple `parity-util-mem` packages in your project, and the specification `parity-util-mem` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  parity-util-mem:0.3.0
  parity-util-mem:0.4.1
```