### PR TITLE
Fix node deletion

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -11,7 +11,7 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.20.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.21.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.16.0" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
-memory-db = { path = "../../memory-db", version = "0.20.0" }
+memory-db = { path = "../../memory-db", version = "0.21.0" }
 trie-root = { path = "../../trie-root", version = "0.16.0" }
-trie-db = { path = "../../trie-db", version = "0.20.0" }
+trie-db = { path = "../../trie-db", version = "0.21.0" }
 criterion = "0.2.8"
 parity-scale-codec = { version = "1.0.3" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -16,13 +16,13 @@ rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.20.0" }
+memory-db = { path = "../memory-db", version = "0.21.0" }
 rand = { version = "0.7", default-features = false, features = ["small_rng"] }
 trie-root = { path = "../trie-root", version = "0.16.0"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.20.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.21.0" }
 hex-literal = "0.2"
 criterion = "0.3"
 parity-codec = "3.0"

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -16,7 +16,7 @@ hex-literal = "0.2"
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.20.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.21.0" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
`death_row` currently records deletions with incorrect partial keys. This leads to a lot of junk in the database.