### PR TITLE
clippy: do not clone a Copy-able var

### DIFF
--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -122,7 +122,7 @@ impl<H: KeyHasher, KF: KeyFunction<H>, T: Clone> Clone for MemoryDB<H, KF, T> {
 	fn clone(&self) -> Self {
 		Self {
 			data: self.data.clone(),
-			hashed_null_node: self.hashed_null_node.clone(),
+			hashed_null_node: self.hashed_null_node,
 			null_node_data: self.null_node_data.clone(),
 			_kf: Default::default(),
 		}
@@ -187,7 +187,7 @@ impl<H: KeyHasher> KeyFunction<H> for HashKey<H> {
 
 /// Make database key from hash only.
 pub fn hash_key<H: KeyHasher>(key: &H::Out, _prefix: Prefix) -> H::Out {
-	key.clone()
+    *key
 }
 
 /// Key function that concatenates prefix and hash.
@@ -574,7 +574,7 @@ where
 
 	fn insert(&mut self, prefix: Prefix, value: &[u8]) -> H::Out {
 		if T::from(value) == self.null_node_data {
-			return self.hashed_null_node.clone();
+			return self.hashed_null_node;
 		}
 
 		let key = H::hash(value);

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -187,7 +187,7 @@ impl<H: KeyHasher> KeyFunction<H> for HashKey<H> {
 
 /// Make database key from hash only.
 pub fn hash_key<H: KeyHasher>(key: &H::Out, _prefix: Prefix) -> H::Out {
-    *key
+	*key
 }
 
 /// Key function that concatenates prefix and hash.

--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -918,7 +918,7 @@ pub fn compare_implementations<X : hash_db::HashDB<KeccakHasher, DBValue> + Eq> 
 			t.insert(&data[i].0[..], &data[i].1[..]).unwrap();
 		}
 		t.commit();
-		t.root().clone()
+		t.root()
 	};
 	if root_new != root {
 		{
@@ -960,7 +960,7 @@ pub fn compare_root(
 		for i in 0..data.len() {
 			t.insert(&data[i].0[..], &data[i].1[..]).unwrap();
 		}
-		t.root().clone()
+		t.root()
 	};
 
 	assert_eq!(root, root_new);
@@ -1075,7 +1075,7 @@ pub fn compare_implementations_no_extension(
 		for i in 0..data.len() {
 			t.insert(&data[i].0[..], &data[i].1[..]).unwrap();
 		}
-		t.root().clone()
+		t.root()
 	};
 	
 	if root != root_new {
@@ -1115,7 +1115,7 @@ pub fn compare_implementations_no_extension_unordered(
 			t.insert(&data[i].0[..], &data[i].1[..]).unwrap();
 			b_map.insert(data[i].0.clone(), data[i].1.clone());
 		}
-		t.root().clone()
+		t.root()
 	};
 	let root_new = {
 		let mut cb = TrieBuilder::new(&mut hashdb);

--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -918,7 +918,7 @@ pub fn compare_implementations<X : hash_db::HashDB<KeccakHasher, DBValue> + Eq> 
 			t.insert(&data[i].0[..], &data[i].1[..]).unwrap();
 		}
 		t.commit();
-		t.root()
+		*t.root()
 	};
 	if root_new != root {
 		{
@@ -960,7 +960,7 @@ pub fn compare_root(
 		for i in 0..data.len() {
 			t.insert(&data[i].0[..], &data[i].1[..]).unwrap();
 		}
-		t.root()
+		*t.root()
 	};
 
 	assert_eq!(root, root_new);
@@ -1075,7 +1075,7 @@ pub fn compare_implementations_no_extension(
 		for i in 0..data.len() {
 			t.insert(&data[i].0[..], &data[i].1[..]).unwrap();
 		}
-		t.root()
+		*t.root()
 	};
 	
 	if root != root_new {
@@ -1115,7 +1115,7 @@ pub fn compare_implementations_no_extension_unordered(
 			t.insert(&data[i].0[..], &data[i].1[..]).unwrap();
 			b_map.insert(data[i].0.clone(), data[i].1.clone());
 		}
-		t.root()
+		*t.root()
 	};
 	let root_new = {
 		let mut cb = TrieBuilder::new(&mut hashdb);

--- a/trie-db/src/iter_build.rs
+++ b/trie-db/src/iter_build.rs
@@ -353,7 +353,7 @@ impl<'a, H: Hasher, V, DB: HashDB<H, V>> ProcessEncodedNode<<H as Hasher>::Out>
 		}
 		let hash = self.db.insert(prefix, &encoded_node[..]);
 		if is_root {
-			self.root = Some(hash.clone());
+			self.root = Some(hash);
 		};
 		ChildReference::Hash(hash)
 	}
@@ -388,7 +388,7 @@ impl<H: Hasher> ProcessEncodedNode<<H as Hasher>::Out> for TrieRoot<H, <H as Has
 		}
 		let hash = <H as Hasher>::hash(&encoded_node[..]);
 		if is_root {
-			self.root = Some(hash.clone());
+			self.root = Some(hash);
 		};
 		ChildReference::Hash(hash)
 	}
@@ -443,7 +443,7 @@ impl<H: Hasher> ProcessEncodedNode<<H as Hasher>::Out> for TrieRootPrint<H, <H a
 		}
 		let hash = <H as Hasher>::hash(&encoded_node[..]);
 		if is_root {
-			self.root = Some(hash.clone());
+			self.root = Some(hash);
 		};
 		println!("	hashed to {:x?}", hash.as_ref());
 		ChildReference::Hash(hash)

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -341,7 +341,7 @@ impl<'a, L: TrieLayout> Iterator for TrieDBNodeIterator<'a, L> {
 					crumb.increment();
 					return Some(Ok((
 						self.key_nibbles.clone(),
-						crumb.hash.clone(),
+						crumb.hash,
 						crumb.node.clone()
 					)));
 				},

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -131,7 +131,7 @@ where
 		Lookup::<L, Q> {
 			db: self.db,
 			query: query,
-			hash: self.root.clone(),
+			hash: *self.root,
 		}.look_up(NibbleSlice::new(key))
 	}
 

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -1245,7 +1245,7 @@ where
 						// only one onward node. use child instead
 						let child = children[a as usize].take()
 							.expect("used_index only set if occupied; qed");
-						let mut key2 = *key;
+						let mut key2 = key.clone();
 						key2.advance((enc_nibble.1.len() * nibble_ops::NIBBLE_PER_BYTE) - enc_nibble.0);
 						let (start, alloc_start, prefix_end) = match key2.left() {
 							(start, None) => (start, None, Some(nibble_ops::push_at_left(0, a, 0))),
@@ -1319,7 +1319,7 @@ where
 				// We could advance key, but this code can also be called
 				// recursively, so there might be some prefix from branch.
 				let last = partial.1[partial.1.len() - 1] & (255 >> 4);
-				let mut key2 = *key;
+				let mut key2 = key.clone();
 				key2.advance((partial.1.len() * nibble_ops::NIBBLE_PER_BYTE) - partial.0 - 1);
 				let (start, alloc_start, prefix_end) = match key2.left() {
 					(start, None) => (start, None, Some(nibble_ops::push_at_left(0, last, 0))),

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -541,7 +541,7 @@ where
 				NodeHandle::Hash(ref hash) => return Lookup::<L, _> {
 					db: &self.db,
 					query: |v: &[u8]| v.to_vec(),
-					hash: hash.clone(),
+					hash: *hash,
 				}.look_up(partial),
 				NodeHandle::InMemory(ref handle) => match self.storage[handle] {
 					Node::Empty => return Ok(None),
@@ -622,7 +622,7 @@ where
 		value: DBValue,
 		old_val: &mut Option<DBValue>,
 	) -> Result<InsertAction<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		let partial = key.clone();
+		let partial = *key;
 
 		#[cfg(feature = "std")]
 		trace!(target: "trie", "augmented (partial: {:?}, value: {:?})", partial, ToHex(&value));
@@ -991,7 +991,7 @@ where
 		key: &mut NibbleFullKey,
 		old_val: &mut Option<DBValue>,
 	) -> Result<Action<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		let partial = key.clone();
+		let partial = *key;
 		Ok(match (node, partial.is_empty()) {
 			(Node::Empty, _) => Action::Delete,
 			(Node::Branch(c, None), true) => Action::Restore(Node::Branch(c, None)),
@@ -1016,7 +1016,7 @@ where
 						"removing value out of branch child, partial={:?}",
 						partial,
 					);
-					let prefix = key.clone();
+					let prefix = *key;
 					key.advance(1);
 					match self.remove_at(child, key, old_val)? {
 						Some((new, changed)) => {
@@ -1072,7 +1072,7 @@ where
 							"removing value out of branch child, partial={:?}",
 							partial,
 						);
-						let prefix = key.clone();
+						let prefix = *key;
 						key.advance(common + 1);
 						match self.remove_at(child, key, old_val)? {
 							Some((new, changed)) => {
@@ -1131,7 +1131,7 @@ where
 					// try to remove from the child branch.
 					#[cfg(feature = "std")]
 					trace!(target: "trie", "removing from extension child, partial={:?}", partial);
-					let prefix = key.clone();
+					let prefix = *key;
 					key.advance(common);
 					match self.remove_at(child_branch, key, old_val)? {
 						Some((new_child, changed)) => {
@@ -1245,7 +1245,7 @@ where
 						// only one onward node. use child instead
 						let child = children[a as usize].take()
 							.expect("used_index only set if occupied; qed");
-						let mut key2 = key.clone();
+						let mut key2 = *key;
 						key2.advance((enc_nibble.1.len() * nibble_ops::NIBBLE_PER_BYTE) - enc_nibble.0);
 						let (start, alloc_start, prefix_end) = match key2.left() {
 							(start, None) => (start, None, Some(nibble_ops::push_at_left(0, a, 0))),
@@ -1319,7 +1319,7 @@ where
 				// We could advance key, but this code can also be called
 				// recursively, so there might be some prefix from branch.
 				let last = partial.1[partial.1.len() - 1] & (255 >> 4);
-				let mut key2 = key.clone();
+				let mut key2 = *key;
 				key2.advance((partial.1.len() * nibble_ops::NIBBLE_PER_BYTE) - partial.0 - 1);
 				let (start, alloc_start, prefix_end) = match key2.left() {
 					(start, None) => (start, None, Some(nibble_ops::push_at_left(0, last, 0))),


### PR DESCRIPTION
This PR removes all clippy warnings pertaining to [this](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy) issue, in which `clone` is called when the object supports the `Copy` trait.