### PR TITLE
Upgrade hasbrown for `memory-db` and `trie-db`

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-parity-util-mem = { version = "0.7.0", default-features = false }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["hashbrown"] }
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.8.0", default-features = false, features = [ "ahash" ] }
 

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.21.1"
+version = "0.21.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -11,9 +11,7 @@ edition = "2018"
 heapsize = { version = "0.4", optional = true }
 parity-util-mem = { version = "0.7.0", default-features = false }
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
-hashbrown = { version = "0.6.3", default-features = false, features = [ "ahash" ] }
-# There's a compilation error with ahash-0.2.17, which is permitted by the 0.2.11 constraint in hashbrown.
-ahash = "0.2.18"
+hashbrown = { version = "0.8.0", default-features = false, features = [ "ahash" ] }
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2"}

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -11,7 +11,7 @@ edition = "2018"
 log = "0.4"
 smallvec = "1.0.0"
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
-hashbrown = { version = "0.6.3", default-features = false }
+hashbrown = { version = "0.8.0", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This upgrades the `hashbrown` dependency and also removes `ahash` from
`memory-db`. This `ahash` dependency actually lead to non-deterministic
builds, as it enabled the `compile-time-rng` feature. As `memory-db`
only included this dependency to pin the version, we can safely remove it.