### PR TITLE
Increment trie-db to prevent build errors

### DIFF
--- a/memory-db/CHANGELOG.md
+++ b/memory-db/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-- Type parameter to count malloc_size_of on memory-db [#94](https://github.com/paritytech/trie/pull/94)
+
+## [0.21.0] - 2020-07-06
+- Type parameter to count `malloc_size_of` on memory-db. [#94](https://github.com/paritytech/trie/pull/94)
+- Update hashbrown to 0.8. [#97](https://github.com/paritytech/trie/pull/97)
 
 ## [0.20.0] - 2020-03-21
 - Update parity-util-mem to v0.6 [#82](https://github.com/paritytech/trie/pull/82)

--- a/memory-db/CHANGELOG.md
+++ b/memory-db/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.21.0] - 2020-07-06
+## [0.22.0] - 2020-07-06
 - Type parameter to count `malloc_size_of` on memory-db. [#94](https://github.com/paritytech/trie/pull/94)
 - Update hashbrown to 0.8. [#97](https://github.com/paritytech/trie/pull/97)
 

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.21.2"
+version = "0.22.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.21.1"
+version = "0.21.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -9,11 +9,9 @@ edition = "2018"
 
 [dependencies]
 heapsize = { version = "0.4", optional = true }
-parity-util-mem = { version = "0.7.0", default-features = false }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["hashbrown"] }
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
-hashbrown = { version = "0.6.3", default-features = false, features = [ "ahash" ] }
-# There's a compilation error with ahash-0.2.17, which is permitted by the 0.2.11 constraint in hashbrown.
-ahash = "0.2.18"
+hashbrown = { version = "0.8.0", default-features = false, features = [ "ahash" ] }
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2"}

--- a/test-support/reference-trie/CHANGELOG.md
+++ b/test-support/reference-trie/CHANGELOG.md
@@ -6,5 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.22.0] - 2020-07-06
+- Update trie-db to 0.22. [#98](https://github.com/paritytech/trie/pull/98)
+
 ## [0.20.0] - 2020-02-07
 - Update trie-root to v0.16.0 and memory-db to v0.19.0 [#78](https://github.com/paritytech/trie/pull/78)

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.21.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.22.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.16.0" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.22.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.23.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.16.0" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -11,12 +11,12 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.23.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.22.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.16.0" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.22.0" }
+trie-bench = { path = "../trie-bench", version = "0.23.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.23.0] - 2020-07-06
+- Update memory-db to 0.22. [#98](https://github.com/paritytech/trie/pull/98)
+
 ## [0.21.0] - 2020-03-21
 - Update memory-db to 0.20.0 [#82](https://github.com/paritytech/trie/pull/82)
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
-memory-db = { path = "../../memory-db", version = "0.21.0" }
+memory-db = { path = "../../memory-db", version = "0.22.0" }
 trie-root = { path = "../../trie-root", version = "0.16.0" }
 trie-db = { path = "../../trie-db", version = "0.22.0" }
 criterion = "0.2.8"

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.21.0" }
 trie-root = { path = "../../trie-root", version = "0.16.0" }
-trie-db = { path = "../../trie-db", version = "0.21.0" }
+trie-db = { path = "../../trie-db", version = "0.22.0" }
 criterion = "0.2.8"
 parity-scale-codec = { version = "1.0.3" }

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog].
 ## [Unreleased]
 
 ## [0.22.0] - 2020-07-06
-- Update memory-db to 0.21. [#94](https://github.com/paritytech/trie/pull/94)
 - Update hashbrown to 0.8. [#97](https://github.com/paritytech/trie/pull/97)
 
 ## [0.21.0] - 2020-06-04

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.22.0] - 2020-07-06
+- Update memory-db to 0.21. [#94](https://github.com/paritytech/trie/pull/94)
+- Update hashbrown to 0.8. [#97](https://github.com/paritytech/trie/pull/97)
+
 ## [0.21.0] - 2020-06-04
 - Added `ALLOW_EMPTY` to `TrieLayout`. [#92](https://github.com/paritytech/trie/pull/92)
 

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -11,7 +11,7 @@ edition = "2018"
 log = "0.4"
 smallvec = "1.0.0"
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
-hashbrown = { version = "0.6.3", default-features = false }
+hashbrown = { version = "0.8.0", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -22,7 +22,7 @@ trie-root = { path = "../trie-root", version = "0.16.0"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.21.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.22.0" }
 hex-literal = "0.2"
 criterion = "0.3"
 parity-codec = "3.0"

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -16,7 +16,7 @@ rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.21.0" }
+memory-db = { path = "../memory-db", version = "0.22.0" }
 rand = { version = "0.7", default-features = false, features = ["small_rng"] }
 trie-root = { path = "../trie-root", version = "0.16.0"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.21.1"
+version = "0.22.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -122,17 +122,7 @@ impl<T, E> fmt::Display for TrieError<T, E> where T: MaybeDebug, E: MaybeDebug {
 }
 
 #[cfg(feature = "std")]
-impl<T, E> Error for TrieError<T, E> where T: fmt::Debug, E: Error {
-	fn description(&self) -> &str {
-		match *self {
-			TrieError::InvalidStateRoot(_) => "Invalid state root",
-			TrieError::IncompleteDatabase(_) => "Incomplete database",
-			TrieError::ValueAtIncompleteKey(_, _) => "Value at incomplete key",
-			TrieError::DecoderError(_, ref err) => err.description(),
-			TrieError::InvalidHash(_, _) => "Encoded node contains invalid hash reference",
-		}
-	}
-}
+impl<T, E> Error for TrieError<T, E> where T: fmt::Debug, E: Error {}
 
 /// Trie result type.
 /// Boxed to avoid copying around extra space for the `Hasher`s `Out` on successful queries.

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -16,7 +16,7 @@ hex-literal = "0.2"
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.21.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.22.0" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Releasing the hasbrown fix as patch version wasn't a good idea as it breaks the build if we not upgrade the other dependencies. To prevent this, we increment the `trie-db` version and yank the old version.