### PR TITLE
Fix memory-db in wasm

### DIFF
--- a/memory-db/CHANGELOG.md
+++ b/memory-db/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.24.0] - 2020-07-07
+- Disable memory tracking for no_std target by default. [#99](https://github.com/paritytech/trie/pull/99)
+
 ## [0.22.0] - 2020-07-06
 - Type parameter to count `malloc_size_of` on memory-db. [#94](https://github.com/paritytech/trie/pull/94)
 - Update hashbrown to 0.8. [#97](https://github.com/paritytech/trie/pull/97)

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.22.0"
+version = "0.24.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -66,6 +66,13 @@ pub trait MaybeDebug {}
 #[cfg(not(feature = "std"))]
 impl<T> MaybeDebug for T {}
 
+/// The default memory tracker used by [`MemoryDB`].
+#[cfg(feature = "std")]
+pub type DefaultMemTracker<T> = MemCounter<T>;
+/// The default memory tracker used by [`MemoryDB`].
+#[cfg(not(feature = "std"))]
+pub type DefaultMemTracker<T> = NoopTracker<T>;
+
 /// Reference-counted memory-based `HashDB` implementation.
 ///
 /// Use `new()` to create a new database. Insert items with `insert()`, remove items
@@ -113,7 +120,7 @@ impl<T> MaybeDebug for T {}
 ///   assert!(!m.contains(&k, EMPTY_PREFIX));
 /// }
 /// ```
-pub struct MemoryDB<H, KF, T, M = MemCounter<T>>
+pub struct MemoryDB<H, KF, T, M = DefaultMemTracker<T>>
 where
 	H: KeyHasher,
 	KF: KeyFunction<H>,

--- a/memory-db/src/malloc_size_of.rs
+++ b/memory-db/src/malloc_size_of.rs
@@ -82,7 +82,21 @@ impl<T: MallocSizeOf> MemTracker<T> for MemCounter<T> {
 
 /// No-op `MemTracker` implementation for when we want to
 /// construct a `MemoryDB` instance that does not track memory usage.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NoopTracker;
+#[derive(PartialEq, Eq)]
+pub struct NoopTracker<T>(PhantomData<T>);
 
-impl<T> MemTracker<T> for NoopTracker {}
+impl<T> Default for NoopTracker<T> {
+	fn default() -> Self {
+		Self(PhantomData)
+	}
+}
+
+impl<T> Clone for NoopTracker<T> {
+	fn clone(&self) -> Self {
+        Self::default()
+	}
+}
+
+impl<T> Copy for NoopTracker<T> {}
+
+impl<T> MemTracker<T> for NoopTracker<T> {}

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.22.0"
+version = "0.24.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -11,12 +11,12 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.22.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.24.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.16.0" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.23.0" }
+trie-bench = { path = "../trie-bench", version = "0.24.0" }
 criterion = "0.2.8"
 
 [[bench]]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.24.0"
+version = "0.22.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -11,7 +11,7 @@ edition = "2018"
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.24.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.22.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.16.0" }
 parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 

--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.24.0] - 2020-07-07
+- Update memory-db to 0.24. [#99](https://github.com/paritytech/trie/pull/99)
+
 ## [0.23.0] - 2020-07-06
 - Update memory-db to 0.22. [#98](https://github.com/paritytech/trie/pull/98)
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -11,8 +11,8 @@ edition = "2018"
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
-memory-db = { path = "../../memory-db", version = "0.22.0" }
+memory-db = { path = "../../memory-db", version = "0.24.0" }
 trie-root = { path = "../../trie-root", version = "0.16.0" }
-trie-db = { path = "../../trie-db", version = "0.22.0" }
+trie-db = { path = "../../trie-db", version = "0.24.0" }
 criterion = "0.2.8"
 parity-scale-codec = { version = "1.0.3" }

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.24.0" }
 trie-root = { path = "../../trie-root", version = "0.16.0" }
-trie-db = { path = "../../trie-db", version = "0.24.0" }
+trie-db = { path = "../../trie-db", version = "0.22.0" }
 criterion = "0.2.8"
 parity-scale-codec = { version = "1.0.3" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.24.0"
+version = "0.22.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -22,7 +22,7 @@ trie-root = { path = "../trie-root", version = "0.16.0"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.24.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.22.0" }
 hex-literal = "0.2"
 criterion = "0.3"
 parity-codec = "3.0"

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.22.0"
+version = "0.24.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -16,13 +16,13 @@ rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 env_logger = "0.6"
-memory-db = { path = "../memory-db", version = "0.22.0" }
+memory-db = { path = "../memory-db", version = "0.24.0" }
 rand = { version = "0.7", default-features = false, features = ["small_rng"] }
 trie-root = { path = "../trie-root", version = "0.16.0"}
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.22.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.24.0" }
 hex-literal = "0.2"
 criterion = "0.3"
 parity-codec = "3.0"

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -16,7 +16,7 @@ hex-literal = "0.2"
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.22.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.24.0" }
 
 [features]
 default = ["std"]

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -16,7 +16,7 @@ hex-literal = "0.2"
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
-reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.24.0" }
+reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.22.0" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
We can not use the `MemCounter` in wasm, because `parity-util-mem`
panics ;) Instead we just use the `NoopTracker` in wasm.