### PR TITLE
Add shrink_to_fit to MemoryDB

### DIFF
--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -330,6 +330,14 @@ where
 			}
 		}
 	}
+
+	/// Shrinks the capacity of the map as much as possible. It will drop
+	/// down as much as possible while maintaining the internal rules
+	/// and possibly leaving some space in accordance with the resize policy.
+	#[inline]
+	pub fn shrink_to_fit(&mut self) {
+		self.data.shrink_to_fit();
+	}
 }
 
 impl<'a, H, KF, T, M> MemoryDB<H, KF, T, M>


### PR DESCRIPTION
In OpenEthereum when snapshotting starts we are restricting new blocks to be saved into our database and we are using MemoryDB to temporarily save them in RAM. And MemoryDB gets really large (13gb is my last count) and this is okay, but after snapshot passes there is no way to shrink back HashMap that is inside of MemoryDB.

This is a simple function that will allow us to do garbage collection and shrink MemoryDB.