### PR TITLE
trie-db: use ahash feature of hashbrown

### DIFF
--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 log = "0.4"
 smallvec = "1.0.0"
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
-hashbrown = { version = "0.8.0", default-features = false }
+hashbrown = { version = "0.8.0", default-features = false, features = ["ahash"] }
 rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #95.

I don't know how to test this in CI properly, because cargo feature resolution in combination with additive features always selects this feature of `hashbrown`.

Tested this locally with a `path` dependency on `trie-db`.