### PR TITLE
*: update criterion to v0.3

### DIFF
--- a/hash256-std-hasher/Cargo.toml
+++ b/hash256-std-hasher/Cargo.toml
@@ -16,7 +16,7 @@ harness = false
 crunchy = "0.2.1"
 
 [dev-dependencies]
-criterion = "0.2.8"
+criterion = "0.3.3"
 
 [features]
 default = ["std"]

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -15,7 +15,7 @@ hashbrown = { version = "0.8.0", default-features = false, features = [ "ahash" 
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2"}
-criterion = "0.2.8"
+criterion = "0.3.3"
 
 [features]
 default = ["std"]

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -17,7 +17,7 @@ parity-scale-codec = { version = "1.0.3", features = ["derive"] }
 
 [dev-dependencies]
 trie-bench = { path = "../trie-bench", version = "0.24.0" }
-criterion = "0.2.8"
+criterion = "0.3.3"
 
 [[bench]]
 name = "bench"

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -14,5 +14,5 @@ hash-db = { path = "../../hash-db" , version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.24.0" }
 trie-root = { path = "../../trie-root", version = "0.16.0" }
 trie-db = { path = "../../trie-db", version = "0.22.0" }
-criterion = "0.2.8"
+criterion = "0.3.3"
 parity-scale-codec = { version = "1.0.3" }

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -15,7 +15,7 @@ hashbrown = { version = "0.8.0", default-features = false, features = ["ahash"] 
 rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
-env_logger = "0.6"
+env_logger = "0.7"
 memory-db = { path = "../memory-db", version = "0.24.0" }
 rand = { version = "0.7", default-features = false, features = ["small_rng"] }
 trie-root = { path = "../trie-root", version = "0.16.0"}
@@ -23,10 +23,8 @@ trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242
 reference-trie = { path = "../test-support/reference-trie", default-features = false, version = "0.22.0" }
-hex-literal = "0.2"
+hex-literal = "0.3"
 criterion = "0.3"
-parity-codec = "3.0"
-parity-codec-derive = "3.0"
 
 [features]
 default = ["std"]

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2" }
 
 [dev-dependencies]
-hex-literal = "0.2"
+hex-literal = "0.3"
 keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../test-support/trie-standardmap", version = "0.15.2" }
 # DISABLE the following line when publishing until cyclic dependencies are resolved https://github.com/rust-lang/cargo/issues/4242


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

need to release a new version of `trie-bench`