### PR TITLE
Change `memory-db` to only use `MemCounter` when a `memory-tracker` feature is activated.

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -18,12 +18,13 @@ keccak-hasher = { path = "../test-support/keccak-hasher", version = "0.15.2"}
 criterion = "0.3.3"
 
 [features]
-default = ["std"]
+default = ["std", "memory-tracker"]
 std = [
   "hash-db/std",
   "parity-util-mem/std",
 ]
 deprecated = [ "heapsize" ]
+memory-tracker = []
 
 [[bench]]
 name = "bench"

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -67,10 +67,10 @@ pub trait MaybeDebug {}
 impl<T> MaybeDebug for T {}
 
 /// The default memory tracker used by [`MemoryDB`].
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "memory-tracker"))]
 pub type DefaultMemTracker<T> = MemCounter<T>;
 /// The default memory tracker used by [`MemoryDB`].
-#[cfg(not(feature = "std"))]
+#[cfg(not(all(feature = "std", feature = "memory-tracker")))]
 pub type DefaultMemTracker<T> = NoopTracker<T>;
 
 /// Reference-counted memory-based `HashDB` implementation.


### PR DESCRIPTION
This fixes https://github.com/paritytech/substrate/issues/6741 as long as the feature is not enabled for the browser node.