### PR TITLE
Seek for prefixed iterator.

### DIFF
--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.22.3"
+version = "0.22.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -231,6 +231,7 @@ impl<'a, L: TrieLayout> TrieDBNodeIterator<'a, L> {
 
 	/// Advance the iterator into a prefix, no value out of the prefix will be accessed
 	/// or returned after this operation.
+	/// Warning prefix iterator may embed non prefix node when there is inline nodes.
 	pub fn prefix(&mut self, prefix: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
 		if self.seek_prefix(prefix)? {
 			if let Some(v) = self.trail.pop() {
@@ -246,6 +247,7 @@ impl<'a, L: TrieLayout> TrieDBNodeIterator<'a, L> {
 
 	/// Advance the iterator into a prefix, no value out of the prefix will be accessed
 	/// or returned after this operation.
+	/// Warning prefix iterator may embed non prefix node when there is inline nodes.
 	pub fn prefix_then_seek(&mut self, prefix: &[u8], seek: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
 		if seek.starts_with(prefix) {
 			if self.seek_prefix(seek)? {

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -250,31 +250,30 @@ impl<'a, L: TrieLayout> TrieDBNodeIterator<'a, L> {
 	/// Warning prefix iterator may embed non prefix node when there is inline nodes.
 	pub fn prefix_then_seek(&mut self, prefix: &[u8], seek: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
 		if seek.starts_with(prefix) {
-			if self.seek_prefix(seek)? {
-				let prefix_len = prefix.len() * crate::nibble::nibble_ops::NIBBLE_PER_BYTE;
-				let mut len = 0;
-				// look first prefix in trail
-				for i in 0..self.trail.len() {
-					match self.trail[i].node.node_plan() {
-						NodePlan::Empty => {},
-						NodePlan::Branch { .. } => {
-							len += 1;
-						},
-						NodePlan::Leaf { partial, .. } => {
-							len += partial.len();
-						},
-						NodePlan::Extension { partial, .. } => {
-							len += partial.len();
-						},
-						NodePlan::NibbledBranch { partial, .. } => {
-							len += 1;
-							len += partial.len();
-						},
-					}
-					if len > prefix_len {
-						self.trail = self.trail.split_off(i);
-						return Ok(());
-					}
+			self.seek_prefix(seek)?;
+			let prefix_len = prefix.len() * crate::nibble::nibble_ops::NIBBLE_PER_BYTE;
+			let mut len = 0;
+			// look first prefix in trail
+			for i in 0..self.trail.len() {
+				match self.trail[i].node.node_plan() {
+					NodePlan::Empty => {},
+					NodePlan::Branch { .. } => {
+						len += 1;
+					},
+					NodePlan::Leaf { partial, .. } => {
+						len += partial.len();
+					},
+					NodePlan::Extension { partial, .. } => {
+						len += partial.len();
+					},
+					NodePlan::NibbledBranch { partial, .. } => {
+						len += 1;
+						len += partial.len();
+					},
+				}
+				if len > prefix_len {
+					self.trail = self.trail.split_off(i);
+					return Ok(());
 				}
 			}
 		}

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -231,7 +231,6 @@ impl<'a, L: TrieLayout> TrieDBNodeIterator<'a, L> {
 
 	/// Advance the iterator into a prefix, no value out of the prefix will be accessed
 	/// or returned after this operation.
-	/// Warning prefix iterator may embed non prefix node when there is inline nodes.
 	pub fn prefix(&mut self, prefix: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
 		if self.seek_prefix(prefix)? {
 			if let Some(v) = self.trail.pop() {
@@ -247,7 +246,6 @@ impl<'a, L: TrieLayout> TrieDBNodeIterator<'a, L> {
 
 	/// Advance the iterator into a prefix, no value out of the prefix will be accessed
 	/// or returned after this operation.
-	/// Warning prefix iterator may embed non prefix node when there is inline nodes.
 	pub fn prefix_then_seek(&mut self, prefix: &[u8], seek: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
 		if seek.starts_with(prefix) {
 			self.seek_prefix(seek)?;

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -244,6 +244,42 @@ impl<'a, L: TrieLayout> TrieDBNodeIterator<'a, L> {
 		Ok(())
 	}
 
+	/// Advance the iterator into a prefix, no value out of the prefix will be accessed
+	/// or returned after this operation.
+	pub fn prefix_then_seek(&mut self, prefix: &[u8], seek: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
+		if seek.starts_with(prefix) {
+			if self.seek_prefix(seek)? {
+				let prefix_len = prefix.len() * crate::nibble::nibble_ops::NIBBLE_PER_BYTE;
+				let mut len = 0;
+				// look first prefix in trail
+				for i in 0..self.trail.len() {
+					match self.trail[i].node.node_plan() {
+						NodePlan::Empty => {},
+						NodePlan::Branch { .. } => {
+							len += 1;
+						},
+						NodePlan::Leaf { partial, .. } => {
+							len += partial.len();
+						},
+						NodePlan::Extension { partial, .. } => {
+							len += partial.len();
+						},
+						NodePlan::NibbledBranch { partial, .. } => {
+							len += 1;
+							len += partial.len();
+						},
+					}
+					if len > prefix_len {
+						self.trail = self.trail.split_off(i);
+						return Ok(());
+					}
+				}
+			}
+		}
+		// default to empty iter
+		self.trail.clear();
+		Ok(())
+	}
 }
 
 impl<'a, L: TrieLayout> TrieIterator<L> for TrieDBNodeIterator<'a, L> {

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -283,6 +283,22 @@ impl<'a, L: TrieLayout> TrieDBIterator<'a, L> {
 		})
 	}
 
+	/// Create a new iterator, but limited to a given prefix.
+	/// It then do a seek operation from prefixed context (using `seek` lose
+	/// prefix context by default).
+	pub fn new_prefixed_then_seek(
+		db: &'a TrieDB<L>,
+		prefix: &[u8],
+		start_at: &[u8],
+	) -> Result<TrieDBIterator<'a, L>, TrieHash<L>, CError<L>> {
+		let mut inner = TrieDBNodeIterator::new(db)?;
+		inner.prefix_then_seek(prefix, start_at)?;
+
+		Ok(TrieDBIterator {
+			inner,
+		})
+	}
+
 }
 
 impl<'a, L: TrieLayout> TrieIterator<L> for TrieDBIterator<'a, L> {

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -298,7 +298,6 @@ impl<'a, L: TrieLayout> TrieDBIterator<'a, L> {
 			inner,
 		})
 	}
-
 }
 
 impl<'a, L: TrieLayout> TrieIterator<L> for TrieDBIterator<'a, L> {

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -212,7 +212,7 @@ fn iterator_without_extension() {
 }
 
 #[test]
-fn iterator_seek2() {
+fn iterator_seek() {
 	let d = vec![
 		b"A".to_vec(),
 		b"AA".to_vec(),


### PR DESCRIPTION
When using 'seek' on a prefixed iterator, prefix context is lost.

This pr adds a function 'prefix_then_seek' for this usecase.