### PR TITLE
Fix read access of changed value in triedbmut.

### DIFF
--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -573,7 +573,7 @@ where
 					},
 					Node::NibbledBranch(ref slice, ref children, ref value) => {
 						let slice = NibbleSlice::from_stored(slice);
-						if partial.is_empty() {
+						if slice == partial {
 							return Ok(value.as_ref().map(|v| v.to_vec()));
 						} else if partial.starts_with(&slice) {
 							let idx = partial.at(0);


### PR DESCRIPTION
This is only for no extension node (this kind of access is not use by substrate and substrate is probably the only user of no extension).
