### PR TITLE
Fix prefix for extension implementation

### DIFF
--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -1171,6 +1171,14 @@ where
 		node: Node<TrieHash<L>>,
 		key: NibbleSlice,
 	) -> Result<Node<TrieHash<L>>, TrieHash<L>, CError<L>> {
+		self.fix_inner(node, key, false)
+	}
+	fn fix_inner(
+		&mut self,
+		node: Node<TrieHash<L>>,
+		key: NibbleSlice,
+		recurse_extension: bool,
+	) -> Result<Node<TrieHash<L>>, TrieHash<L>, CError<L>> {
 		match node {
 			Node::Branch(mut children, value) => {
 				// if only a single value, transmute to leaf/extension and feed through fixed.
@@ -1179,7 +1187,7 @@ where
 					None,
 					One(u8),
 					Many,
-				};
+				}
 				let mut used_index = UsedIndex::None;
 				for i in 0..16 {
 					match (children[i].is_none(), &used_index) {
@@ -1225,7 +1233,7 @@ where
 					None,
 					One(u8),
 					Many,
-				};
+				}
 				let mut used_index = UsedIndex::None;
 				for i in 0..16 {
 					match (children[i].is_none(), &used_index) {
@@ -1316,19 +1324,32 @@ where
 				}
 			},
 			Node::Extension(partial, child) => {
-				// We could advance key, but this code can also be called
-				// recursively, so there might be some prefix from branch.
-				let last = partial.1[partial.1.len() - 1] & (255 >> 4);
 				let mut key2 = key.clone();
-				key2.advance((partial.1.len() * nibble_ops::NIBBLE_PER_BYTE) - partial.0 - 1);
-				let (start, alloc_start, prefix_end) = match key2.left() {
-					(start, None) => (start, None, Some(nibble_ops::push_at_left(0, last, 0))),
-					(start, Some(v)) => {
-						let mut so: BackingByteVec = start.into();
-						// Complete last byte with `last`.
-						so.push(nibble_ops::pad_left(v) | last);
-						(start, Some(so), None)
-					},
+				let (start, alloc_start, prefix_end) = if !recurse_extension {
+					// We could advance key, but this code can also be called
+					// recursively, so there might be some prefix from branch.
+					let last = partial.1[partial.1.len() - 1] & (255 >> 4);
+					key2.advance((partial.1.len() * nibble_ops::NIBBLE_PER_BYTE) - partial.0 - 1);
+					match key2.left() {
+						(start, None) => (start, None, Some(nibble_ops::push_at_left(0, last, 0))),
+						(start, Some(v)) => {
+							let mut so: BackingByteVec = start.into();
+							// Complete last byte with `last`.
+							so.push(nibble_ops::pad_left(v) | last);
+							(start, Some(so), None)
+						},
+					}
+				} else {
+					let k2 = key2.left();
+
+					let mut so: NibbleVec = Default::default();
+					so.append_optional_slice_and_nibble(Some(&NibbleSlice::new(k2.0)), None);
+					if let Some(n) = k2.1 {
+						so.push(n >> nibble_ops::BIT_PER_NIBBLE);
+					}
+					so.append_optional_slice_and_nibble(Some(&NibbleSlice::from_stored(&partial)), None);
+					let so = so.as_prefix();
+					(k2.0, Some(so.0.into()), so.1)
 				};
 				let child_prefix = (alloc_start.as_ref().map(|start| &start[..]).unwrap_or(start), prefix_end);
 
@@ -1363,7 +1384,8 @@ where
 							"fixing: extension combination. new_partial={:?}",
 							partial,
 						);
-						self.fix(Node::Extension(partial, sub_child), key)
+						
+						self.fix_inner(Node::Extension(partial, sub_child), key, true)
 					}
 					Node::Leaf(sub_partial, value) => {
 						// combine with node below.

--- a/trie-db/test/src/triedbmut.rs
+++ b/trie-db/test/src/triedbmut.rs
@@ -72,7 +72,7 @@ fn reference_hashed_null_node() -> <KeccakHasher as Hasher>::Out {
 fn playpen() {
 	env_logger::init();
 	let mut seed = Default::default();
-	for test_i in 0..10 {
+	for test_i in 0..10_000 {
 		if test_i % 50 == 0 {
 			debug!("{:?} of 10000 stress tests done", test_i);
 		}
@@ -115,7 +115,7 @@ fn playpen() {
 
 	// no_extension
 	let mut seed = Default::default();
-	for test_i in 0..10 {
+	for test_i in 0..10_000 {
 		if test_i % 50 == 0 {
 			debug!("{:?} of 10000 stress tests done", test_i);
 		}


### PR DESCRIPTION
There was an issue with prefix calculation when calling `fix` function recursively for extension (on removal).
The combination of db using node prefix and trie layout with extension is not something that I believe is use anywhere.