### PR TITLE
Allow consuming iterator when decoding compact proof.

### DIFF
--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.22.5"
+version = "0.22.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -71,7 +71,8 @@ pub use crate::node_codec::{NodeCodec, Partial};
 pub use crate::iter_build::{trie_visit, ProcessEncodedNode,
 	 TrieBuilder, TrieRoot, TrieRootUnhashed};
 pub use crate::iterator::TrieDBNodeIterator;
-pub use crate::trie_codec::{decode_compact, decode_compact_from_iter, encode_compact};
+pub use crate::trie_codec::{decode_compact, decode_compact_from_iter,
+	decode_compact_from_iter_owned, encode_compact};
 
 #[cfg(feature = "std")]
 pub use crate::iter_build::TrieRootPrint;


### PR DESCRIPTION
In cumulus, decoding involve *2 size of proof memory usage from pvf.

This PR switch trie_codec to allow consuming iterator : see `decode_compact_from_iter_owned` that will allow
us to do iteraton on  storage proof in a consuming way with cumulus.

Something like 
```
let mut nodes = storage_proof.encoded_nodes;
nodes.reverse();
let root = match sp_trie::decode_compact_owned::<sp_trie::Layout<HashFor<B>>, _, _>(
		&mut db,
		sp_std::iter::from_fn(move|| nodes.pop()),
		Some(parent_head.state_root()),
	) {
```	
Note that there will always be a time when we got twice the memory of a single node, but that is the same for any storage read.


cc\ @bkchr 