### PR TITLE
Bump parity-scale-codec to 2.2.0-rc.1

### DIFF
--- a/test-support/reference-trie/CHANGELOG.md
+++ b/test-support/reference-trie/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.23.1] - 2021-06-23
-- Update parity-scale-codec to 2.2.0-rc.1.
+## [0.23.1] - 2021-06-24
+- Update parity-scale-codec to 2.2.0-rc.2.
 ## [0.23.0] - 2021-01-27
 - Update parity-scale-codec to 2.0.
 

--- a/test-support/reference-trie/CHANGELOG.md
+++ b/test-support/reference-trie/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.23.1] - 2021-06-23
+- Update parity-scale-codec to 2.2.0-rc.1.
 ## [0.23.0] - 2021-01-27
 - Update parity-scale-codec to 2.0.
 

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -13,7 +13,7 @@ hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.3" }
 trie-db = { path = "../../trie-db", default-features = false, version = "0.22.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.16.0" }
-parity-scale-codec = { version = "2.2.0-rc.1", features = ["derive"] }
+parity-scale-codec = { version = "2.2.0-rc.2", features = ["derive"] }
 
 [dev-dependencies]
 trie-bench = { path = "../trie-bench", version = "0.27.1" }

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -13,10 +13,10 @@ hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.3" }
 trie-db = { path = "../../trie-db", default-features = false, version = "0.22.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.16.0" }
-parity-scale-codec = { version = "2.0.0", features = ["derive"] }
+parity-scale-codec = { version = "2.2.0-rc.1", features = ["derive"] }
 
 [dev-dependencies]
-trie-bench = { path = "../trie-bench", version = "0.27.0" }
+trie-bench = { path = "../trie-bench", version = "0.27.1" }
 criterion = "0.3.3"
 
 [[bench]]

--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-## [0.27.1] - 2021-06-23
-- Update parity-scale-codec to 2.2.0-rc.1.
+## [0.27.1] - 2021-06-24
+- Update parity-scale-codec to 2.2.0-rc.2.
 ## [0.27.0] - 2021-01-27
 - Update memory-db to 0.26.
 - Update parity-scale-codec to 2.0.

--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
-
+## [0.27.1] - 2021-06-23
+- Update parity-scale-codec to 2.2.0-rc.1.
 ## [0.27.0] - 2021-01-27
 - Update memory-db to 0.26.
 - Update parity-scale-codec to 2.0.

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -15,4 +15,4 @@ memory-db = { path = "../../memory-db", version = "0.26.0" }
 trie-root = { path = "../../trie-root", version = "0.16.0" }
 trie-db = { path = "../../trie-db", version = "0.22.0" }
 criterion = "0.3.3"
-parity-scale-codec = { version = "2.2.0-rc.1" }
+parity-scale-codec = { version = "2.2.0-rc.2" }

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -15,4 +15,4 @@ memory-db = { path = "../../memory-db", version = "0.26.0" }
 trie-root = { path = "../../trie-root", version = "0.16.0" }
 trie-db = { path = "../../trie-db", version = "0.22.0" }
 criterion = "0.3.3"
-parity-scale-codec = { version = "2.0.0" }
+parity-scale-codec = { version = "2.2.0-rc.1" }


### PR DESCRIPTION
Part of https://github.com/paritytech/substrate/pull/9163.

This is a pre-release so that we can experiment a bit more with the `MaxEncodedLen` trait if needed, but since Cargo wants pre-releases to be explicitly specified (and are not considered automatically SemVer-compatible), this does exactly that. That's also needed so that we can select a single `parity-scale-codec` version in the Substrate crate graph.