### PR TITLE
Use GitHub Actions CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/paritytech/trie.svg?branch=master)](https://travis-ci.com/paritytech/trie)
+[![Build Status](https://github.com/paritytech/trie/actions/workflows/rust.yml/badge.svg)](https://github.com/paritytech/trie/actions)
 # Trie
 
 A generic implementation of the Base-16 Modified Merkle Tree ("Trie") data structure,


### PR DESCRIPTION
I just noticed the CI badge still refers to Travis CI which was dropped at https://github.com/paritytech/trie/pull/113.
So, I think it's good to use the badge for GitHub Actions badge instead.

| Before | After |
| --- | --- | 
| <img width="144" alt="image" src="https://user-images.githubusercontent.com/6782666/132119766-401c0836-755e-493e-af62-7388ed082718.png"> | <img width="156" alt="image" src="https://user-images.githubusercontent.com/6782666/132119772-3b50b653-1029-4416-b877-b4746590fbca.png"> |
