### PR TITLE
Fix hex trace output

### DIFF
--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -1635,7 +1635,7 @@ where
 					}
 				});
 				#[cfg(feature = "std")]
-				trace!(target: "trie", "encoded root node: {:x?}", &encoded_root[..]);
+				trace!(target: "trie", "encoded root node: {:?}", ToHex(&encoded_root[..]));
 
 				*self.root = self.db.insert(EMPTY_PREFIX, &encoded_root[..]);
 				self.hash_count += 1;
@@ -1752,7 +1752,7 @@ where
 		let mut old_val = None;
 
 		#[cfg(feature = "std")]
-		trace!(target: "trie", "insert: key={:x?}, value={:?}", key, ToHex(&value));
+		trace!(target: "trie", "insert: key={:?}, value={:?}", ToHex(key), ToHex(&value));
 
 		let root_handle = self.root_handle();
 		let (new_handle, _changed) =
@@ -1767,7 +1767,7 @@ where
 
 	fn remove(&mut self, key: &[u8]) -> Result<Option<Value<L>>, TrieHash<L>, CError<L>> {
 		#[cfg(feature = "std")]
-		trace!(target: "trie", "remove: key={:x?}", key);
+		trace!(target: "trie", "remove: key={:?}", ToHex(key));
 
 		let root_handle = self.root_handle();
 		let mut key_slice = NibbleSlice::new(key);

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -1635,7 +1635,7 @@ where
 					}
 				});
 				#[cfg(feature = "std")]
-				trace!(target: "trie", "encoded root node: {:#x?}", &encoded_root[..]);
+				trace!(target: "trie", "encoded root node: {:x?}", &encoded_root[..]);
 
 				*self.root = self.db.insert(EMPTY_PREFIX, &encoded_root[..]);
 				self.hash_count += 1;
@@ -1752,7 +1752,7 @@ where
 		let mut old_val = None;
 
 		#[cfg(feature = "std")]
-		trace!(target: "trie", "insert: key={:#x?}, value={:?}", key, ToHex(&value));
+		trace!(target: "trie", "insert: key={:x?}, value={:?}", key, ToHex(&value));
 
 		let root_handle = self.root_handle();
 		let (new_handle, _changed) =
@@ -1767,7 +1767,7 @@ where
 
 	fn remove(&mut self, key: &[u8]) -> Result<Option<Value<L>>, TrieHash<L>, CError<L>> {
 		#[cfg(feature = "std")]
-		trace!(target: "trie", "remove: key={:#x?}", key);
+		trace!(target: "trie", "remove: key={:x?}", key);
 
 		let root_handle = self.root_handle();
 		let mut key_slice = NibbleSlice::new(key);


### PR DESCRIPTION
The trie trace logs use one line per byte, making it unreadable.  
Instead put it in one line. 

There is no test for this but I tested it in the [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b19c89e680851fdbdf683b605d2b8227).