### PR TITLE
Do not check for root in `TrieDB` and `TrieDBMut` constructors

### DIFF
--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -928,7 +928,7 @@ where
 	if root_new != root {
 		{
 			let db: &dyn hash_db::HashDB<_, _> = &hashdb;
-			let t = TrieDB::<T>::new(&db, &root_new).unwrap();
+			let t = TrieDB::<T>::new(&db, &root_new);
 			println!("{:?}", t);
 			for a in t.iter().unwrap() {
 				println!("a:{:x?}", a);
@@ -936,7 +936,7 @@ where
 		}
 		{
 			let db: &dyn hash_db::HashDB<_, _> = &memdb;
-			let t = TrieDB::<T>::new(&db, &root).unwrap();
+			let t = TrieDB::<T>::new(&db, &root);
 			println!("{:?}", t);
 			for a in t.iter().unwrap() {
 				println!("a:{:x?}", a);
@@ -1048,7 +1048,7 @@ pub fn compare_implementations_unordered<T, DB>(
 	if root != root_new {
 		{
 			let db: &dyn hash_db::HashDB<_, _> = &memdb;
-			let t = TrieDB::<T>::new(&db, &root).unwrap();
+			let t = TrieDB::<T>::new(&db, &root);
 			println!("{:?}", t);
 			for a in t.iter().unwrap() {
 				println!("a:{:?}", a);
@@ -1056,7 +1056,7 @@ pub fn compare_implementations_unordered<T, DB>(
 		}
 		{
 			let db: &dyn hash_db::HashDB<_, _> = &hashdb;
-			let t = TrieDB::<T>::new(&db, &root_new).unwrap();
+			let t = TrieDB::<T>::new(&db, &root_new);
 			println!("{:?}", t);
 			for a in t.iter().unwrap() {
 				println!("a:{:?}", a);
@@ -1086,7 +1086,7 @@ pub fn compare_insert_remove<T, DB: hash_db::HashDB<T::Hash, DBValue>>(
 	while a < data.len() {
 		// new triemut every 3 element
 		root = {
-			let mut t = TrieDBMut::<T>::from_existing(&mut memdb, &mut root).unwrap();
+			let mut t = TrieDBMut::<T>::from_existing(&mut memdb, &mut root);
 			for _ in 0..3 {
 				if data[a].0 {
 					// remove
@@ -1107,7 +1107,7 @@ pub fn compare_insert_remove<T, DB: hash_db::HashDB<T::Hash, DBValue>>(
 			*t.root()
 		};
 	}
-	let mut t = TrieDBMut::<T>::from_existing(&mut memdb, &mut root).unwrap();
+	let mut t = TrieDBMut::<T>::from_existing(&mut memdb, &mut root);
 	// we are testing the RefTrie code here so we do not sort or check uniqueness
 	// before.
 	assert_eq!(*t.root(), calc_root::<T, _, _, _>(data2));

--- a/test-support/trie-bench/src/lib.rs
+++ b/test-support/trie-bench/src/lib.rs
@@ -81,7 +81,7 @@ fn benchmark<L: TrieLayout, S: TrieStream>(
 				}
 			}
 			b.iter(&mut || {
-				let t = TrieDB::<L>::new(&memdb, &root).unwrap();
+				let t = TrieDB::<L>::new(&memdb, &root);
 				for n in t.iter().unwrap() {
 					black_box(n).unwrap();
 				}

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Do not check for root in `TrieDB` and `TrieDBMut` constructors: [#155](https://github.com/paritytech/trie/pull/155)
+
+  To get back the old behavior you have to add the following code:
+  ```
+  if !db.contains(root, EMPTY_PREFIX) {
+    return Err(InvalidStateRoot(root))
+  }
+  ```
 
 ## [0.23.1] - 2022-02-04
 - Updated `hashbrown` to 0.12. [#150](https://github.com/paritytech/trie/pull/150)

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -41,8 +41,8 @@ where
 	pub fn new(
 		db: &'db dyn HashDBRef<L::Hash, DBValue>,
 		root: &'db TrieHash<L>,
-	) -> Result<Self, TrieHash<L>, CError<L>> {
-		Ok(FatDB { raw: TrieDB::new(db, root)? })
+	) -> Self {
+		FatDB { raw: TrieDB::new(db, root) }
 	}
 
 	/// Get the backing database.

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -38,10 +38,7 @@ where
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(
-		db: &'db dyn HashDBRef<L::Hash, DBValue>,
-		root: &'db TrieHash<L>,
-	) -> Self {
+	pub fn new(db: &'db dyn HashDBRef<L::Hash, DBValue>, root: &'db TrieHash<L>) -> Self {
 		FatDB { raw: TrieDB::new(db, root) }
 	}
 

--- a/trie-db/src/fatdbmut.rs
+++ b/trie-db/src/fatdbmut.rs
@@ -43,8 +43,8 @@ where
 	pub fn from_existing(
 		db: &'db mut dyn HashDB<L::Hash, DBValue>,
 		root: &'db mut TrieHash<L>,
-	) -> Result<Self, TrieHash<L>, CError<L>> {
-		Ok(FatDBMut { raw: TrieDBMut::from_existing(db, root)? })
+	) -> Self {
+		FatDBMut { raw: TrieDBMut::from_existing(db, root) }
 	}
 
 	/// Get the backing database.

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -33,16 +33,15 @@ impl<'db, L> SecTrieDB<'db, L>
 where
 	L: TrieLayout,
 {
-	/// Create a new trie with the backing database `db` and empty `root`
+	/// Create a new trie with the backing database `db` and `root`.
 	///
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	/// Returns an error if root does not exist.
 	pub fn new(
 		db: &'db dyn HashDBRef<L::Hash, DBValue>,
 		root: &'db TrieHash<L>,
-	) -> Result<Self, TrieHash<L>, CError<L>> {
-		Ok(SecTrieDB { raw: TrieDB::new(db, root)? })
+	) -> Self{
+		SecTrieDB { raw: TrieDB::new(db, root) }
 	}
 
 	/// Get a reference to the underlying raw `TrieDB` struct.

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -37,10 +37,7 @@ where
 	///
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(
-		db: &'db dyn HashDBRef<L::Hash, DBValue>,
-		root: &'db TrieHash<L>,
-	) -> Self{
+	pub fn new(db: &'db dyn HashDBRef<L::Hash, DBValue>, root: &'db TrieHash<L>) -> Self {
 		SecTrieDB { raw: TrieDB::new(db, root) }
 	}
 

--- a/trie-db/src/sectriedbmut.rs
+++ b/trie-db/src/sectriedbmut.rs
@@ -38,13 +38,11 @@ where
 	}
 
 	/// Create a new trie with the backing database `db` and `root`.
-	///
-	/// Returns an error if root does not exist.
 	pub fn from_existing(
 		db: &'db mut dyn HashDB<L::Hash, DBValue>,
 		root: &'db mut TrieHash<L>,
-	) -> Result<Self, TrieHash<L>, CError<L>> {
-		Ok(SecTrieDBMut { raw: TrieDBMut::from_existing(db, root)? })
+	) -> Self {
+		SecTrieDBMut { raw: TrieDBMut::from_existing(db, root) }
 	}
 
 	/// Get the backing database.

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -44,7 +44,7 @@ use crate::rstd::{fmt, vec::Vec};
 /// let mut memdb = MemoryDB::<KeccakHasher, HashKey<_>, _>::default();
 /// let mut root = Default::default();
 /// RefTrieDBMut::new(&mut memdb, &mut root).insert(b"foo", b"bar").unwrap();
-/// let t = RefTrieDB::new(&memdb, &root).unwrap();
+/// let t = RefTrieDB::new(&memdb, &root);
 /// assert!(t.contains(b"foo").unwrap());
 /// assert_eq!(t.get(b"foo").unwrap().unwrap(), b"bar".to_vec());
 /// ```
@@ -62,22 +62,11 @@ impl<'db, L> TrieDB<'db, L>
 where
 	L: TrieLayout,
 {
-	/// Create a new trie with the backing database `db` and `root`
-	/// Returns an error if `root` does not exist
-	pub fn new(
-		db: &'db dyn HashDBRef<L::Hash, DBValue>,
-		root: &'db TrieHash<L>,
-	) -> Result<Self, TrieHash<L>, CError<L>> {
-		if !db.contains(root, EMPTY_PREFIX) {
-			Err(Box::new(TrieError::InvalidStateRoot(*root)))
-		} else {
-			Ok(TrieDB { db, root, hash_count: 0 })
-		}
-	}
-
-	/// `new_with_layout`, but do not check root presence, if missing
-	/// this will fail at first node access.
-	pub fn new_unchecked(db: &'db dyn HashDBRef<L::Hash, DBValue>, root: &'db TrieHash<L>) -> Self {
+	/// Create a new trie with the backing database `db` and `root`.
+	///
+	/// This doesn't check if `root` exists in the given `db`. If `root` doesn't exist it will fail
+	/// when trying to lookup any key.
+	pub fn new(db: &'db dyn HashDBRef<L::Hash, DBValue>, root: &'db TrieHash<L>) -> Self {
 		TrieDB { db, root, hash_count: 0 }
 	}
 

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -588,26 +588,25 @@ where
 		}
 	}
 
-	/// Create a new trie with the backing database `db` and `root.
-	/// Returns an error if `root` does not exist.
+	/// Create a new trie with the backing database `db` and `root`.
+	///
+	/// This doesn't check if `root` exists in the given `db`. If `root` doesn't exist it will fail
+	/// when trying to lookup any key.
 	pub fn from_existing(
 		db: &'a mut dyn HashDB<L::Hash, DBValue>,
 		root: &'a mut TrieHash<L>,
-	) -> Result<Self, TrieHash<L>, CError<L>> {
-		if !db.contains(root, EMPTY_PREFIX) {
-			return Err(Box::new(TrieError::InvalidStateRoot(*root)))
-		}
-
+	) -> Self {
 		let root_handle = NodeHandle::Hash(*root);
-		Ok(TrieDBMut {
+		TrieDBMut {
 			storage: NodeStorage::empty(),
 			db,
 			root,
 			root_handle,
 			death_row: HashSet::new(),
 			hash_count: 0,
-		})
+		}
 	}
+
 	/// Get the backing database.
 	pub fn db(&self) -> &dyn HashDB<L::Hash, DBValue> {
 		self.db

--- a/trie-db/test/benches/bench.rs
+++ b/trie-db/test/benches/bench.rs
@@ -464,7 +464,7 @@ fn trie_iteration(c: &mut Criterion) {
 
 	c.bench_function("trie_iteration", move |b: &mut Bencher| {
 		b.iter(|| {
-			let trie = trie_db::TrieDB::<Layout>::new(&mdb, &root).unwrap();
+			let trie = trie_db::TrieDB::<Layout>::new(&mdb, &root);
 			let mut iter = trie_db::TrieDBNodeIterator::new(&trie).unwrap();
 			assert!(iter.all(|result| result.is_ok()));
 		})
@@ -485,7 +485,7 @@ fn trie_proof_verification(c: &mut Criterion) {
 	let mut mdb = memory_db::MemoryDB::<_, HashKey<_>, _>::default();
 	let root = reference_trie::calc_root_build::<Layout, _, _, _, _>(data, &mut mdb);
 
-	let trie = trie_db::TrieDB::<Layout>::new(&mdb, &root).unwrap();
+	let trie = trie_db::TrieDB::<Layout>::new(&mdb, &root);
 	let proof = generate_proof(&trie, keys.iter()).unwrap();
 	let items = keys
 		.into_iter()

--- a/trie-db/test/src/fatdb.rs
+++ b/trie-db/test/src/fatdb.rs
@@ -24,7 +24,7 @@ fn fatdb_to_trie() {
 		let mut t = RefFatDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
 	}
-	let t = RefFatDB::new(&memdb, &root).unwrap();
+	let t = RefFatDB::new(&memdb, &root);
 	assert_eq!(t.get(&[0x01u8, 0x23]).unwrap().unwrap(), vec![0x01u8, 0x23]);
 	assert_eq!(
 		t.iter().unwrap().map(Result::unwrap).collect::<Vec<_>>(),

--- a/trie-db/test/src/fatdbmut.rs
+++ b/trie-db/test/src/fatdbmut.rs
@@ -25,7 +25,7 @@ fn fatdbmut_to_trie() {
 		let mut t = RefFatDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
 	}
-	let t = RefTrieDB::new(&memdb, &root).unwrap();
+	let t = RefTrieDB::new(&memdb, &root);
 	assert_eq!(t.get(&RefHasher::hash(&[0x01u8, 0x23])), Ok(Some(vec![0x01u8, 0x23])),);
 }
 

--- a/trie-db/test/src/iter_build.rs
+++ b/trie-db/test/src/iter_build.rs
@@ -50,7 +50,7 @@ fn test_iter<T: TrieLayout>(data: Vec<(Vec<u8>, Vec<u8>)>) {
 			t.insert(key, value).unwrap();
 		}
 	}
-	let t = TrieDB::<T>::new(&db, &root).unwrap();
+	let t = TrieDB::<T>::new(&db, &root);
 	for (i, kv) in t.iter().unwrap().enumerate() {
 		let (k, v) = kv.unwrap();
 		let key: &[u8] = &data[i].0;

--- a/trie-db/test/src/iterator.rs
+++ b/trie-db/test/src/iterator.rs
@@ -60,7 +60,7 @@ fn iterator_works_internal<T: TrieLayout>() {
 	];
 
 	let (memdb, root) = build_trie_db::<T>(&pairs);
-	let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let trie = TrieDB::<T>::new(&memdb, &root);
 	let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 
 	if T::USE_EXTENSION {
@@ -186,7 +186,7 @@ fn iterator_works_internal<T: TrieLayout>() {
 test_layouts!(iterator_over_empty_works, iterator_over_empty_works_internal);
 fn iterator_over_empty_works_internal<T: TrieLayout>() {
 	let (memdb, root) = build_trie_db::<T>(&[]);
-	let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let trie = TrieDB::<T>::new(&memdb, &root);
 	let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 
 	match iter.next() {
@@ -212,7 +212,7 @@ fn seek_works_internal<T: TrieLayout>() {
 	];
 
 	let (memdb, root) = build_trie_db::<T>(&pairs);
-	let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let trie = TrieDB::<T>::new(&memdb, &root);
 	let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 
 	TrieIterator::seek(&mut iter, &hex!("")[..]).unwrap();
@@ -246,7 +246,7 @@ fn seek_works_internal<T: TrieLayout>() {
 test_layouts!(seek_over_empty_works, seek_over_empty_works_internal);
 fn seek_over_empty_works_internal<T: TrieLayout>() {
 	let (memdb, root) = build_trie_db::<T>(&[]);
-	let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let trie = TrieDB::<T>::new(&memdb, &root);
 	let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 
 	TrieIterator::seek(&mut iter, &hex!("")[..]).unwrap();
@@ -278,7 +278,7 @@ fn iterate_over_incomplete_db_internal<T: TrieLayout>() {
 
 	// Look up the leaf node with prefix "02".
 	let leaf_hash = {
-		let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+		let trie = TrieDB::<T>::new(&memdb, &root);
 		let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 
 		TrieIterator::seek(&mut iter, &hex!("02")[..]).unwrap();
@@ -297,7 +297,7 @@ fn iterate_over_incomplete_db_internal<T: TrieLayout>() {
 
 	// Seek to missing node returns error.
 	{
-		let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+		let trie = TrieDB::<T>::new(&memdb, &root);
 		let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 
 		match TrieIterator::seek(&mut iter, &hex!("02")[..]) {
@@ -311,7 +311,7 @@ fn iterate_over_incomplete_db_internal<T: TrieLayout>() {
 
 	// Iterate over missing node works.
 	{
-		let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+		let trie = TrieDB::<T>::new(&memdb, &root);
 		let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 
 		TrieIterator::seek(&mut iter, &hex!("0130")[..]).unwrap();
@@ -347,7 +347,7 @@ fn prefix_works_internal<T: TrieLayout>() {
 	];
 
 	let (memdb, root) = build_trie_db::<T>(&pairs);
-	let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let trie = TrieDB::<T>::new(&memdb, &root);
 	let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 
 	iter.prefix(&hex!("01").to_vec()[..]).unwrap();
@@ -408,7 +408,7 @@ fn prefix_works_internal<T: TrieLayout>() {
 test_layouts!(prefix_over_empty_works, prefix_over_empty_works_internal);
 fn prefix_over_empty_works_internal<T: TrieLayout>() {
 	let (memdb, root) = build_trie_db::<T>(&[]);
-	let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let trie = TrieDB::<T>::new(&memdb, &root);
 	let mut iter = TrieDBNodeIterator::new(&trie).unwrap();
 	iter.prefix(&hex!("")[..]).unwrap();
 	match iter.next() {

--- a/trie-db/test/src/proof.rs
+++ b/trie-db/test/src/proof.rs
@@ -62,7 +62,7 @@ fn test_generate_proof<L: TrieLayout>(
 	};
 
 	// Generate proof for the given keys..
-	let trie = <TrieDB<L>>::new(&db, &root).unwrap();
+	let trie = <TrieDB<L>>::new(&db, &root);
 	let proof = generate_proof::<_, L, _, _>(&trie, keys.iter()).unwrap();
 	let items = keys.into_iter().map(|key| (key, trie.get(key).unwrap())).collect();
 

--- a/trie-db/test/src/recorder.rs
+++ b/trie-db/test/src/recorder.rs
@@ -73,7 +73,7 @@ fn trie_record() {
 		x.insert(b"yo ho ho", b"and a bottle of rum").unwrap();
 	}
 
-	let trie = RefTrieDB::new(&db, &root).unwrap();
+	let trie = RefTrieDB::new(&db, &root);
 	let mut recorder = Recorder::new();
 
 	trie.get_with(b"pirate", &mut recorder).unwrap().unwrap();

--- a/trie-db/test/src/sectriedb.rs
+++ b/trie-db/test/src/sectriedb.rs
@@ -25,6 +25,6 @@ fn trie_to_sectrie() {
 		let mut t = RefTrieDBMut::new(&mut db, &mut root);
 		t.insert(&RefHasher::hash(&[0x01u8, 0x23]), &[0x01u8, 0x23]).unwrap();
 	}
-	let t = RefSecTrieDB::new(&db, &root).unwrap();
+	let t = RefSecTrieDB::new(&db, &root);
 	assert_eq!(t.get(&[0x01u8, 0x23]).unwrap().unwrap(), vec![0x01u8, 0x23]);
 }

--- a/trie-db/test/src/sectriedbmut.rs
+++ b/trie-db/test/src/sectriedbmut.rs
@@ -25,6 +25,6 @@ fn sectrie_to_trie() {
 		let mut t = RefSecTrieDBMut::new(&mut memdb, &mut root);
 		t.insert(&[0x01u8, 0x23], &[0x01u8, 0x23]).unwrap();
 	}
-	let t = RefTrieDB::new(&memdb, &root).unwrap();
+	let t = RefTrieDB::new(&memdb, &root);
 	assert_eq!(t.get(&RefHasher::hash(&[0x01u8, 0x23])).unwrap().unwrap(), vec![0x01u8, 0x23],);
 }

--- a/trie-db/test/src/trie_codec.rs
+++ b/trie-db/test/src/trie_codec.rs
@@ -46,7 +46,7 @@ fn test_encode_compact<L: TrieLayout>(
 	let mut recorder = Recorder::new();
 	let items = {
 		let mut items = Vec::with_capacity(keys.len());
-		let trie = <TrieDB<L>>::new(&db, &root).unwrap();
+		let trie = <TrieDB<L>>::new(&db, &root);
 		for key in keys {
 			let value = trie.get_with(key, &mut recorder).unwrap();
 			items.push((key, value));
@@ -62,7 +62,7 @@ fn test_encode_compact<L: TrieLayout>(
 
 	// Compactly encode the partial trie DB.
 	let compact_trie = {
-		let trie = <TrieDB<L>>::new(&partial_db, &root).unwrap();
+		let trie = <TrieDB<L>>::new(&partial_db, &root);
 		encode_compact::<L>(&trie).unwrap()
 	};
 
@@ -82,7 +82,7 @@ fn test_decode_compact<L: TrieLayout>(
 	assert_eq!(used, expected_used);
 
 	// Check that lookups for all items succeed.
-	let trie = <TrieDB<L>>::new(&db, &root).unwrap();
+	let trie = <TrieDB<L>>::new(&db, &root);
 	for (key, expected_value) in items {
 		assert_eq!(trie.get(key).unwrap(), expected_value);
 	}

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -36,7 +36,7 @@ fn iterator_works_internal<T: TrieLayout>() {
 		}
 	}
 
-	let trie = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let trie = TrieDB::<T>::new(&memdb, &root);
 
 	let iter = trie.iter().unwrap();
 	let mut iter_pairs = Vec::new();
@@ -64,7 +64,7 @@ fn iterator_seek_works_internal<T: TrieLayout>() {
 		}
 	}
 
-	let t = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let t = TrieDB::<T>::new(&memdb, &root);
 
 	let mut iter = t.iter().unwrap();
 	assert_eq!(
@@ -97,7 +97,7 @@ fn iterator_internal<T: TrieLayout>() {
 		}
 	}
 
-	let t = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let t = TrieDB::<T>::new(&memdb, &root);
 	assert_eq!(
 		d.iter().map(|i| i.clone()).collect::<Vec<_>>(),
 		t.iter().unwrap().map(|x| x.unwrap().0).collect::<Vec<_>>()
@@ -119,7 +119,7 @@ fn iterator_seek_internal<T: TrieLayout>() {
 		}
 	}
 
-	let t = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let t = TrieDB::<T>::new(&memdb, &root);
 	let mut iter = t.iter().unwrap();
 	assert_eq!(iter.next().unwrap().unwrap(), (b"A".to_vec(), vals[0].clone()));
 	iter.seek(b"!").unwrap();
@@ -167,7 +167,7 @@ fn get_length_with_extension_internal<T: TrieLayout>() {
 		t.insert(b"B", b"ABCBAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
 	}
 
-	let t = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let t = TrieDB::<T>::new(&memdb, &root);
 	assert_eq!(t.get_with(b"A", |x: &[u8]| x.len()).unwrap(), Some(3));
 	assert_eq!(t.get_with(b"B", |x: &[u8]| x.len()).unwrap(), Some(32));
 	assert_eq!(t.get_with(b"C", |x: &[u8]| x.len()).unwrap(), None);
@@ -186,7 +186,7 @@ fn debug_output_supports_pretty_print_internal<T: TrieLayout>() {
 		}
 		t.root().clone()
 	};
-	let t = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let t = TrieDB::<T>::new(&memdb, &root);
 
 	if T::USE_EXTENSION {
 		assert_eq!(
@@ -268,7 +268,7 @@ fn test_lookup_with_corrupt_data_returns_decoder_error_internal<T: TrieLayout>()
 		t.insert(b"B", b"ABCBA").unwrap();
 	}
 
-	let t = TrieDB::<T>::new(&memdb, &root).unwrap();
+	let t = TrieDB::<T>::new(&memdb, &root);
 
 	// query for an invalid data type to trigger an error
 	let q = |x: &[u8]| x.len() < 64;

--- a/trie-db/test/src/triedbmut.rs
+++ b/trie-db/test/src/triedbmut.rs
@@ -360,7 +360,7 @@ fn test_at_one_and_two_internal<T: TrieLayout>() {
 		assert_eq!(t.get(&[0x1, 0x23]).unwrap().unwrap(), vec![0x1u8, 0x23]);
 		t.insert(&[0x01u8, 0x23, 0x00], &[0x01u8, 0x24]).unwrap();
 	}
-	let mut t = TrieDBMut::<T>::from_existing(&mut memdb, &mut root).unwrap();
+	let mut t = TrieDBMut::<T>::from_existing(&mut memdb, &mut root);
 	t.insert(&[0x01u8, 0x23, 0x00], &[0x01u8, 0x25]).unwrap();
 	// This test that middle node get resolved correctly (modified
 	// triedbmut node due to change of child node).
@@ -549,7 +549,7 @@ fn register_proof_without_value() {
 	let mut root = Default::default();
 	let _ = populate_trie::<Layout>(&mut memdb, &mut root, &x);
 	{
-		let trie = TrieDB::<Layout>::new(&memdb, &root).unwrap();
+		let trie = TrieDB::<Layout>::new(&memdb, &root);
 		println!("{:?}", trie);
 	}
 
@@ -600,7 +600,7 @@ fn register_proof_without_value() {
 
 	let root_proof = root.clone();
 	{
-		let mut trie = TrieDBMut::<Layout>::from_existing(&mut memdb, &mut root).unwrap();
+		let mut trie = TrieDBMut::<Layout>::from_existing(&mut memdb, &mut root);
 		// touch te value (test1 remains untouch).
 		trie.get(b"te").unwrap();
 		// cut test_1234 prefix
@@ -623,8 +623,7 @@ fn register_proof_without_value() {
 	let mut memdb_from_proof = db_unpacked.clone();
 	let mut root_proof = root_unpacked.clone();
 	{
-		let mut trie =
-			TrieDBMut::<Layout>::from_existing(&mut memdb_from_proof, &mut root_proof).unwrap();
+		let mut trie = TrieDBMut::<Layout>::from_existing(&mut memdb_from_proof, &mut root_proof);
 		trie.get(b"te").unwrap();
 		trie.insert(b"test12", &[2u8; 36][..]).unwrap();
 		trie.remove(b"test1234").unwrap();
@@ -634,7 +633,7 @@ fn register_proof_without_value() {
 	let mut root_proof = root_unpacked.clone();
 	{
 		use trie_db::Trie;
-		let trie = TrieDB::<Layout>::new(&memdb_from_proof, &root_proof).unwrap();
+		let trie = TrieDB::<Layout>::new(&memdb_from_proof, &root_proof);
 		assert!(trie.get(b"te").unwrap().is_some());
 		assert!(matches!(
 			trie.get(b"test1").map_err(|e| *e),
@@ -643,8 +642,7 @@ fn register_proof_without_value() {
 	}
 
 	{
-		let trie =
-			TrieDBMut::<Layout>::from_existing(&mut memdb_from_proof, &mut root_proof).unwrap();
+		let trie = TrieDBMut::<Layout>::from_existing(&mut memdb_from_proof, &mut root_proof);
 		assert!(trie.get(b"te").unwrap().is_some());
 		assert!(matches!(
 			trie.get(b"test1").map_err(|e| *e),

--- a/trie-eip1186/test/src/eip1186.rs
+++ b/trie-eip1186/test/src/eip1186.rs
@@ -58,7 +58,7 @@ fn test_generate_proof<L: TrieLayout>(
 		(db, root)
 	};
 	// Generate proof for the given keys..
-	let trie = <TrieDB<L>>::new(&db, &root).unwrap();
+	let trie = <TrieDB<L>>::new(&db, &root);
 	let proof = generate_proof::<_, L>(&trie, key).unwrap();
 	(root, proof.0, proof.1)
 }


### PR DESCRIPTION
This leads to one extra storage lookup before we are doing the actual key lookup. This leads to reading the `root` twice
when just wanting to lookup one key in the trie. We also return an error on lookup anyway if `root` doesn't exists, so
there is really no need to do this twice.