### PR TITLE
memory-db: update parity-util-mem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ members = [
 	"trie-root",
 	"trie-root/test"
 ]
-
-[patch.crates-io]
-parity-util-mem = { git = "https://github.com/paritytech/parity-common", branch = "ao-release-is-coming" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ members = [
 	"trie-root",
 	"trie-root/test"
 ]
+
+[patch.crates-io]
+parity-util-mem = { git = "https://github.com/paritytech/parity-common", branch = "ao-release-is-coming" }

--- a/memory-db/CHANGELOG.md
+++ b/memory-db/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.30.0] - 2022-09-20
+- Update `parity-util-mem` to 0.12. [#166](https://github.com/paritytech/trie/pull/166)
+
 ## [0.29.0] - 2022-02-04
 - Update `parity-util-mem` to 0.11. [#150](https://github.com/paritytech/trie/pull/150)
 

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-parity-util-mem = { version = "0.11.0", default-features = false, features = ["hashbrown"] }
+parity-util-mem = { version = "0.12.0", default-features = false, features = ["hashbrown"] }
 hash-db = { version = "0.15.2", path = "../hash-db", default-features = false }
 hashbrown = { version = "0.12.0", default-features = false, features = [ "ahash" ] }
 

--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.32.0] - 2022-09-20
+- Updated `memory-db` to 0.30. [#166](https://github.com/paritytech/trie/pull/166)
+
 ## [0.31.0] - 2022-08-04
 - Update trie-db to 0.24.0. [#163](https://github.com/paritytech/trie/pull/163)
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.31.0"
+version = "0.32.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ edition = "2018"
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
 trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
-memory-db = { path = "../../memory-db", version = "0.29.0" }
+memory-db = { path = "../../memory-db", version = "0.30.0" }
 trie-root = { path = "../../trie-root", version = "0.17.0" }
 trie-db = { path = "../../trie-db", version = "0.24.0" }
 criterion = "0.3.3"

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db-test"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-db crate"
 repository = "https://github.com/paritytech/trie"
@@ -15,7 +15,7 @@ harness = false
 trie-db = { path = "..", version = "0.24.0"}
 hash-db = { path = "../../hash-db", version = "0.15.2"}
 rustc-hex = { version = "2.1.0" }
-memory-db = { path = "../../memory-db", version = "0.29.0" }
+memory-db = { path = "../../memory-db", version = "0.30.0" }
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 trie-root = { path = "../../trie-root", version = "0.17.0"}
 trie-standardmap = { path = "../../test-support/trie-standardmap", version = "0.15.2" }

--- a/trie-eip1186/test/Cargo.toml
+++ b/trie-eip1186/test/Cargo.toml
@@ -12,4 +12,4 @@ trie-eip1186 = { path = "..", version = "0.2.0"}
 trie-db = { path = "../../trie-db", version = "0.24.0"}
 hash-db = { path = "../../hash-db", version = "0.15.2"}
 reference-trie = { path = "../../test-support/reference-trie", version = "0.26.0" }
-memory-db = { path = "../../memory-db", version = "0.29.0" }
+memory-db = { path = "../../memory-db", version = "0.30.0" }


### PR DESCRIPTION
Depends on https://github.com/paritytech/parity-common/pull/680.