### PR TITLE
Don't allow bitmap without children.

### DIFF
--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -133,7 +133,11 @@ const BITMAP_LENGTH: usize = 2;
 
 impl Bitmap {
 	fn decode(data: &[u8]) -> Result<Self, CodecError> {
-		Ok(u16::decode(&mut &data[..]).map(|v| Bitmap(v))?)
+		let value = u16::decode(&mut &data[..])?;
+		if value == 0 {
+			return Err(CodecError::from("Bad format"))
+		}
+		Ok(Bitmap(value))
 	}
 
 	fn value_at(&self, i: usize) -> bool {


### PR DESCRIPTION
Small codec change to forbid branch with no children in proofs.
We should also forbid branch with one children and no value, but this is currently a valid decoding for some compact proof form.