### PR TITLE
Expand `NibbleVec` by 4 bytes (that was previously wasted as padding)

### DIFF
--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
-smallvec = "1.0.0"
+smallvec = { version = "1.0.0", features = ["union", "const_new"] }
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 hashbrown = { version = "0.12.0", default-features = false, features = ["ahash"] }
 rustc-hex = { version = "2.1.0", default-features = false, optional = true }

--- a/trie-db/src/nibble/mod.rs
+++ b/trie-db/src/nibble/mod.rs
@@ -142,7 +142,7 @@ pub mod nibble_ops {
 }
 
 /// Backing storage for `NibbleVec`s.
-pub(crate) type BackingByteVec = smallvec::SmallVec<[u8; 36]>;
+pub(crate) type BackingByteVec = smallvec::SmallVec<[u8; 40]>;
 
 /// Owning, nibble-oriented byte vector. Counterpart to `NibbleSlice`.
 /// Nibbles are always left aligned, so making a `NibbleVec` from
@@ -186,4 +186,14 @@ pub struct NibbleSlice<'a> {
 pub struct NibbleSliceIterator<'a> {
 	p: &'a NibbleSlice<'a>,
 	i: usize,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn nibble_vec_size() {
+		assert_eq!(std::mem::size_of::<NibbleVec>(), 56);
+	}
 }


### PR DESCRIPTION
I'm trying to do some refactoring of the iterators here, and I noticed that the `NibbleVec` technically wastes 4 bytes of space that otherwise could be used. Fixing this might or might not help anything, but it certainly triggers my OCD, so here's a PR that bumps the size so that no bytes are left behind.

The `size_of::<NibbleVec>()` remains unchanged before and after.