### PR TITLE
Iterator refactoring

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.3" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.24.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.25.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.17.0" }
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 hashbrown = { version = "0.13.2", default-features = false, features = ["ahash"] }

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.31.0" }
 trie-root = { path = "../../trie-root", version = "0.17.0" }
-trie-db = { path = "../../trie-db", version = "0.24.0" }
+trie-db = { path = "../../trie-db", version = "0.25.0" }
 criterion = "0.4.0"
 parity-scale-codec = "3.0.0"

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+- Updated `hashbrown` to 0.13.2: [#177](https://github.com/paritytech/trie/pull/177)
+- Iterator refactoring:
+  - Removed `TrieDBNodeIterator`, `TrieDBKeyIterator::suspend` and `SuspendedTrieDBKeyIterator`
+  - Added `TrieDBRawIterator`
 
 ## [0.24.0] - 2022-08-04
 - Do not check for root in `TrieDB` and `TrieDBMut` constructors: [#155](https://github.com/paritytech/trie/pull/155)

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 - Updated `hashbrown` to 0.13.2: [#177](https://github.com/paritytech/trie/pull/177)
-- Iterator refactoring:
-  - Removed `TrieDBNodeIterator`, `TrieDBKeyIterator::suspend` and `SuspendedTrieDBKeyIterator`
+- Iterator refactoring: [#181](https://github.com/paritytech/trie/pull/181)
+  - Removed `TrieDBKeyIterator::suspend` and `SuspendedTrieDBKeyIterator`
   - Added `TrieDBRawIterator`
 
 ## [0.24.0] - 2022-08-04

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+
+## [0.25.0] - 2023-02-03
 - Updated `hashbrown` to 0.13.2: [#177](https://github.com/paritytech/trie/pull/177)
 - Iterator refactoring: [#181](https://github.com/paritytech/trie/pull/181)
   - Removed `TrieDBKeyIterator::suspend` and `SuspendedTrieDBKeyIterator`

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/fuzz/Cargo.toml
+++ b/trie-db/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 hash-db = { path = "../../hash-db", version = "0.15.2" }
-memory-db = { path = "../../memory-db", version = "0.29.0" }
+memory-db = { path = "../../memory-db", version = "0.31.0" }
 reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }
 
 [dependencies.trie-db]

--- a/trie-db/fuzz/Cargo.toml
+++ b/trie-db/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 hash-db = { path = "../../hash-db", version = "0.15.2" }
 memory-db = { path = "../../memory-db", version = "0.29.0" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.26.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }
 
 [dependencies.trie-db]
 path = ".."

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -128,7 +128,7 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 	/// share its prefix with the node.
 	/// This indicates if there is still nodes to iterate over in the case
 	/// where we limit iteration to 'key' as a prefix.
-	pub(crate) fn seek_prefix(
+	pub(crate) fn seek(
 		&mut self,
 		db: &TrieDB<L>,
 		key: &[u8],
@@ -268,7 +268,7 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 	/// Advance the iterator into a prefix, no value out of the prefix will be accessed
 	/// or returned after this operation.
 	fn prefix(&mut self, db: &TrieDB<L>, prefix: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		if self.seek_prefix(db, prefix)? {
+		if self.seek(db, prefix)? {
 			if let Some(v) = self.trail.pop() {
 				self.trail.clear();
 				self.trail.push(v);
@@ -289,7 +289,7 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 		seek: &[u8],
 	) -> Result<(), TrieHash<L>, CError<L>> {
 		if seek.starts_with(prefix) {
-			self.seek_prefix(db, seek)?;
+			self.seek(db, seek)?;
 			let prefix_len = prefix.len() * crate::nibble::nibble_ops::NIBBLE_PER_BYTE;
 			let mut len = 0;
 			// look first prefix in trail
@@ -590,7 +590,7 @@ impl<'a, 'cache, L: TrieLayout> TrieDBNodeIterator<'a, 'cache, L> {
 
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBNodeIterator<'a, 'cache, L> {
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek_prefix(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key).map(|_| ())
 	}
 }
 

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -537,9 +537,7 @@ impl<'a, 'cache, L: TrieLayout> TrieDBNodeIterator<'a, 'cache, L> {
 	) -> Result<DBValue, TrieHash<L>, CError<L>> {
 		TrieDBRawIterator::fetch_value(self.db, key, prefix)
 	}
-}
 
-impl<'a, 'cache, L: TrieLayout> TrieDBNodeIterator<'a, 'cache, L> {
 	/// Advance the iterator into a prefix, no value out of the prefix will be accessed
 	/// or returned after this operation.
 	pub fn prefix(&mut self, prefix: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -113,7 +113,6 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 
 	/// Fetch value by hash at a current node height
 	fn fetch_value(
-		&self,
 		db: &TrieDB<L>,
 		key: &[u8],
 		prefix: Prefix,
@@ -481,7 +480,7 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 						))))
 					}
 					let value = match maybe_value.expect("None checked above.") {
-						Value::Node(hash) => match self.fetch_value(db, &hash, (key_slice, None)) {
+						Value::Node(hash) => match Self::fetch_value(db, &hash, (key_slice, None)) {
 							Ok(value) => value,
 							Err(err) => return Some(Err(err)),
 						},
@@ -563,7 +562,7 @@ impl<'a, 'cache, L: TrieLayout> TrieDBNodeIterator<'a, 'cache, L> {
 		key: &[u8],
 		prefix: Prefix,
 	) -> Result<DBValue, TrieHash<L>, CError<L>> {
-		self.raw_iter.fetch_value(self.db, key, prefix)
+		TrieDBRawIterator::fetch_value(self.db, key, prefix)
 	}
 }
 

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -71,7 +71,7 @@ pub use self::{
 };
 pub use crate::{
 	iter_build::{trie_visit, ProcessEncodedNode, TrieBuilder, TrieRoot, TrieRootUnhashed},
-	iterator::TrieDBNodeIterator,
+	iterator::{TrieDBNodeIterator, TrieDBRawIterator},
 	node_codec::{NodeCodec, Partial},
 	trie_codec::{decode_compact, decode_compact_from_iter, encode_compact},
 };

--- a/trie-db/src/nibble/nibblevec.rs
+++ b/trie-db/src/nibble/nibblevec.rs
@@ -185,6 +185,7 @@ impl NibbleVec {
 
 	/// Utility function for `append_optional_slice_and_nibble` after a clone.
 	/// Can be slow.
+	#[cfg(feature = "std")]
 	pub(crate) fn clone_append_optional_slice_and_nibble(
 		&self,
 		o_slice: Option<&NibbleSlice>,

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -12,21 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
-use crate::nibble::NibbleVec;
 use crate::{
 	iterator::TrieDBRawIterator,
 	lookup::Lookup,
 	nibble::NibbleSlice,
-	node::{decode_hash, Node, NodeHandle, OwnedNode},
+	node::{decode_hash, NodeHandle, OwnedNode},
 	rstd::boxed::Box,
 	CError, DBValue, Query, Result, Trie, TrieAccess, TrieCache, TrieError, TrieHash, TrieItem,
 	TrieIterator, TrieKeyItem, TrieLayout, TrieRecorder,
 };
-use hash_db::{HashDBRef, Prefix, EMPTY_PREFIX};
-
 #[cfg(feature = "std")]
-use crate::rstd::{fmt, vec::Vec};
+use crate::{
+	nibble::NibbleVec,
+	node::Node,
+	rstd::{fmt, vec::Vec},
+};
+use hash_db::{HashDBRef, Prefix, EMPTY_PREFIX};
 
 /// A builder for creating a [`TrieDB`].
 pub struct TrieDBBuilder<'db, 'cache, L: TrieLayout> {

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -91,7 +91,6 @@ impl<'db, 'cache, L: TrieLayout> TrieDBBuilder<'db, 'cache, L> {
 			root: self.root,
 			cache: self.cache.map(core::cell::RefCell::new),
 			recorder: self.recorder.map(core::cell::RefCell::new),
-			hash_count: 0,
 		}
 	}
 }
@@ -124,8 +123,6 @@ where
 {
 	db: &'db dyn HashDBRef<L::Hash, DBValue>,
 	root: &'db TrieHash<L>,
-	/// The number of hashes performed so far in operations on this trie.
-	hash_count: usize,
 	cache: Option<core::cell::RefCell<&'cache mut dyn TrieCache<L::Codec>>>,
 	recorder: Option<core::cell::RefCell<&'cache mut dyn TrieRecorder<TrieHash<L>>>>,
 }
@@ -392,7 +389,6 @@ where
 {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("TrieDB")
-			.field("hash_count", &self.hash_count)
 			.field(
 				"root",
 				&TrieAwareDebugNode {

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -456,7 +456,7 @@ impl<'a, 'cache, L: TrieLayout> TrieDBIterator<'a, 'cache, L> {
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBIterator<'a, 'cache, L> {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek_prefix(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key).map(|_| ())
 	}
 }
 
@@ -499,7 +499,7 @@ impl<'a, 'cache, L: TrieLayout> TrieDBKeyIterator<'a, 'cache, L> {
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBKeyIterator<'a, 'cache, L> {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek_prefix(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key).map(|_| ())
 	}
 }
 

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db-test"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-db crate"
 repository = "https://github.com/paritytech/trie"
@@ -12,12 +12,12 @@ name = "bench"
 harness = false
 
 [dependencies]
-trie-db = { path = "..", version = "0.24.0"}
+trie-db = { path = "..", version = "0.25.0"}
 hash-db = { path = "../../hash-db", version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.31.0" }
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 trie-standardmap = { path = "../../test-support/trie-standardmap", version = "0.15.2" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.26.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }
 hex-literal = "0.3"
 criterion = "0.4.0"
 env_logger = { version = "0.10", default-features = false }

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -204,7 +204,6 @@ fn debug_output_supports_pretty_print_internal<T: TrieLayout>() {
 		assert_eq!(
 			format!("{:#?}", t),
 			"TrieDB {
-    hash_count: 0,
     root: Node::Extension {
         slice: 4,
         item: Node::Branch {

--- a/trie-eip1186/Cargo.toml
+++ b/trie-eip1186/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-eip1186"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "EIP-1186 compliant proof generation and verification"
 repository = "https://github.com/paritytech/trie"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-db = { path = "../trie-db", default-features = false, version = "0.24"}
+trie-db = { path = "../trie-db", default-features = false, version = "0.25"}
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 
 [features]

--- a/trie-eip1186/test/Cargo.toml
+++ b/trie-eip1186/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-eip1186-test"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-eip1186 crate"
 repository = "https://github.com/paritytech/trie"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-eip1186 = { path = "..", version = "0.2.0"}
-trie-db = { path = "../../trie-db", version = "0.24.0"}
+trie-eip1186 = { path = "..", version = "0.3.0"}
+trie-db = { path = "../../trie-db", version = "0.25.0"}
 hash-db = { path = "../../hash-db", version = "0.15.2"}
-reference-trie = { path = "../../test-support/reference-trie", version = "0.26.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }
 memory-db = { path = "../../memory-db", version = "0.31.0" }

--- a/trie-root/test/Cargo.toml
+++ b/trie-root/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root-test"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests fo trie-root crate"
 repository = "https://github.com/paritytech/trie"
@@ -12,4 +12,4 @@ edition = "2018"
 trie-root = { path = "..", version = "0.17.0" }
 hex-literal = "0.3"
 keccak-hasher = { path = "../../test-support/keccak-hasher", version = "0.15.2" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.26.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }


### PR DESCRIPTION
This PR simplifies and refactors the iterators in `trie-db`.

The changes can be summarized as follows:

* Added `TrieDBNodeIterator`-like `TrieDBRawIterator` and made it lifetimeless (instead of storing a `&TrieDB` it now takes it as a parameter during the iteration)
* `SuspendedTrieDBKeyIterator` was removed since the `TrieDBRawIterator` is a complete replacement for it (with the added bonus that it can be iterated on)
* `TrieDBIterator::next` and `TrieDBKeyIterator::next` were renamed and moved into `TrieDBRawIterator` with no changes to the logic (except making them use `&TrieDB` passed as a parameter instead of the one stored in `self`, and cleaning them up slightly)
* `TrieDBIterator` and `TrieDBKeyIterator` now use `TrieDBRawIterator` under the hood
* A bunch of `#[inline]`s were added to make recreating a `&TrieDB` on each iteration into a zero-cost operation
* All of the relevant crate versions were bumped

This makes further refactoring of storage iterators in `substrate` possible.