### PR TITLE
Return `Arc` instead of `Rc` from the iterators to make them `Send`

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 keccak-hasher = { path = "../keccak-hasher", version = "0.15.3" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.25.1" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.26.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.17.0" }
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 hashbrown = { version = "0.13.2", default-features = false, features = ["ahash"] }

--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -1153,6 +1153,12 @@ mod tests {
 	use super::*;
 	use trie_db::{nibble_ops::NIBBLE_PER_BYTE, node::Node};
 
+	const _: fn() -> () = || {
+		struct AssertTrieDBRawIteratorIsSendAndSync
+		where
+			trie_db::TrieDBRawIterator<NoExtensionLayout>: Send + Sync;
+	};
+
 	#[test]
 	fn test_encoding_simple_trie() {
 		for prefix in

--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.36.0] - 2023-02-24
+- Updated `trie-db` to 0.26.0. [#185](https://github.com/paritytech/trie/pull/185)
+
 ## [0.35.0] - 2023-02-03
 - Updated `trie-db` to 0.25.0.
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
 hash-db = { path = "../../hash-db" , version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.31.0" }
 trie-root = { path = "../../trie-root", version = "0.17.0" }
-trie-db = { path = "../../trie-db", version = "0.25.1" }
+trie-db = { path = "../../trie-db", version = "0.26.0" }
 criterion = "0.4.0"
 parity-scale-codec = "3.0.0"

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.26.0]
+- `TrieDBRawIterator` and `TrieDBNodeIterator` now return a node inside of an `Arc` instead of `Rc`
+
 ## [0.25.1] - 2023-02-14
 - Fix recorder behavior: [#184](https://github.com/paritytech/trie/pull/184)
 

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
-## [0.26.0]
-- `TrieDBRawIterator` and `TrieDBNodeIterator` now return a node inside of an `Arc` instead of `Rc`
+## [0.26.0] - 2023-02-24
+- `TrieDBRawIterator` and `TrieDBNodeIterator` now return a node inside of an `Arc` instead of `Rc` [#185](https://github.com/paritytech/trie/pull/185)
+- `TrieDBRawIterator` is now `Send` and `Sync` [#185](https://github.com/paritytech/trie/pull/185)
 
 ## [0.25.1] - 2023-02-14
 - Fix recorder behavior: [#184](https://github.com/paritytech/trie/pull/184)

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/fuzz/Cargo.toml
+++ b/trie-db/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 hash-db = { path = "../../hash-db", version = "0.15.2" }
 memory-db = { path = "../../memory-db", version = "0.31.0" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.28.0" }
 
 [dependencies.trie-db]
 path = ".."

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -112,7 +112,7 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 	}
 
 	/// Fetch value by hash at a current node height
-	fn fetch_value(
+	pub(crate) fn fetch_value(
 		db: &TrieDB<L>,
 		key: &[u8],
 		prefix: Prefix,
@@ -324,7 +324,7 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 	/// Fetches the next raw item.
 	//
 	/// Must be called with the same `db` as when the iterator was created.
-	fn next_raw_item(
+	pub(crate) fn next_raw_item(
 		&mut self,
 		db: &TrieDB<L>,
 	) -> Option<

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -28,7 +28,7 @@
 use crate::{
 	nibble_ops::NIBBLE_LENGTH,
 	node::{Node, NodeHandle, NodeHandlePlan, NodePlan, OwnedNode, ValuePlan},
-	rstd::{boxed::Box, convert::TryInto, marker::PhantomData, rc::Rc, result, vec, vec::Vec},
+	rstd::{boxed::Box, convert::TryInto, marker::PhantomData, result, sync::Arc, vec, vec::Vec},
 	CError, ChildReference, DBValue, NibbleVec, NodeCodec, Result, TrieDB, TrieDBRawIterator,
 	TrieError, TrieHash, TrieLayout,
 };
@@ -38,7 +38,7 @@ struct EncoderStackEntry<C: NodeCodec> {
 	/// The prefix is the nibble path to the node in the trie.
 	prefix: NibbleVec,
 	/// Node in memory content.
-	node: Rc<OwnedNode<DBValue>>,
+	node: Arc<OwnedNode<DBValue>>,
 	/// The next entry in the stack is a child of the preceding entry at this index. For branch
 	/// nodes, the index is in [0, NIBBLE_LENGTH] and for extension nodes, the index is in [0, 1].
 	child_index: usize,

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db-test"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-db crate"
 repository = "https://github.com/paritytech/trie"
@@ -12,12 +12,12 @@ name = "bench"
 harness = false
 
 [dependencies]
-trie-db = { path = "..", version = "0.25.1"}
+trie-db = { path = "..", version = "0.26.0"}
 hash-db = { path = "../../hash-db", version = "0.15.2"}
 memory-db = { path = "../../memory-db", version = "0.31.0" }
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 trie-standardmap = { path = "../../test-support/trie-standardmap", version = "0.15.2" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.28.0" }
 hex-literal = "0.3"
 criterion = "0.4.0"
 env_logger = { version = "0.10", default-features = false }

--- a/trie-eip1186/Cargo.toml
+++ b/trie-eip1186/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-eip1186"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "EIP-1186 compliant proof generation and verification"
 repository = "https://github.com/paritytech/trie"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-db = { path = "../trie-db", default-features = false, version = "0.25"}
+trie-db = { path = "../trie-db", default-features = false, version = "0.26.0"}
 hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
 
 [features]

--- a/trie-eip1186/test/Cargo.toml
+++ b/trie-eip1186/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-eip1186-test"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-eip1186 crate"
 repository = "https://github.com/paritytech/trie"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-eip1186 = { path = "..", version = "0.3.0"}
-trie-db = { path = "../../trie-db", version = "0.25.1"}
+trie-eip1186 = { path = "..", version = "0.4.0"}
+trie-db = { path = "../../trie-db", version = "0.26.0"}
 hash-db = { path = "../../hash-db", version = "0.15.2"}
-reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.28.0" }
 memory-db = { path = "../../memory-db", version = "0.31.0" }

--- a/trie-root/test/Cargo.toml
+++ b/trie-root/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root-test"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests fo trie-root crate"
 repository = "https://github.com/paritytech/trie"
@@ -12,4 +12,4 @@ edition = "2018"
 trie-root = { path = "..", version = "0.17.0" }
 hex-literal = "0.3"
 keccak-hasher = { path = "../../test-support/keccak-hasher", version = "0.15.2" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.27.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.28.0" }


### PR DESCRIPTION
This PR replaces the `Rc` that's returned by the iterators with an `Arc`.

I need this to make the iterators `Send`, which I need for further performance improvements in `substrate`.