### PR TITLE
remove hash of known value for leaf in compact proof.

### DIFF
--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+- Fix compact proof to skip including value node hashes [#187](https://github.com/paritytech/trie/pull/187)
+
 ## [0.26.0] - 2023-02-24
 - `TrieDBRawIterator` and `TrieDBNodeIterator` now return a node inside of an `Arc` instead of `Rc` [#185](https://github.com/paritytech/trie/pull/185)
 - `TrieDBRawIterator` is now `Send` and `Sync` [#185](https://github.com/paritytech/trie/pull/185)

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -111,7 +111,16 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 			self.node.node_plan()
 		};
 		let mut encoded = match node_plan {
-			NodePlan::Empty | NodePlan::Leaf { .. } => node_data.to_vec(),
+			NodePlan::Empty => node_data.to_vec(),
+			NodePlan::Leaf { partial, value } => {
+				if self.omit_value {
+					let partial = partial.build(node_data);
+				let value = value.build(node_data);
+				C::leaf_node(partial.right_iter(), partial.len(), value)
+				} else {
+					node_data.to_vec()
+				}
+			},
 			NodePlan::Extension { partial, child: _ } =>
 				if !self.omit_children[0] {
 					node_data.to_vec()

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -112,15 +112,14 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 		};
 		let mut encoded = match node_plan {
 			NodePlan::Empty => node_data.to_vec(),
-			NodePlan::Leaf { partial, value } => {
+			NodePlan::Leaf { partial, value } =>
 				if self.omit_value {
 					let partial = partial.build(node_data);
-				let value = value.build(node_data);
-				C::leaf_node(partial.right_iter(), partial.len(), value)
+					let value = value.build(node_data);
+					C::leaf_node(partial.right_iter(), partial.len(), value)
 				} else {
 					node_data.to_vec()
-				}
-			},
+				},
 			NodePlan::Extension { partial, child: _ } =>
 				if !self.omit_children[0] {
 					node_data.to_vec()

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 use hash_db::{HashDB, Prefix};
 
-const OMMIT_VALUE_HASH: crate::node::Value<'static> = crate::node::Value::Inline(&[]);
+const OMIT_VALUE_HASH: crate::node::Value<'static> = crate::node::Value::Inline(&[]);
 
 struct EncoderStackEntry<C: NodeCodec> {
 	/// The prefix is the nibble path to the node in the trie.
@@ -107,7 +107,7 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 			NodePlan::Leaf { partial, value: _ } =>
 				if self.omit_value {
 					let partial = partial.build(node_data);
-					C::leaf_node(partial.right_iter(), partial.len(), OMMIT_VALUE_HASH)
+					C::leaf_node(partial.right_iter(), partial.len(), OMIT_VALUE_HASH)
 				} else {
 					node_data.to_vec()
 				},
@@ -121,7 +121,7 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 				},
 			NodePlan::Branch { value, children } => {
 				let value = if self.omit_value {
-					value.is_some().then_some(OMMIT_VALUE_HASH)
+					value.is_some().then_some(OMIT_VALUE_HASH)
 				} else {
 					value.as_ref().map(|v| v.build(node_data))
 				};
@@ -133,7 +133,7 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 			NodePlan::NibbledBranch { partial, value, children } => {
 				let partial = partial.build(node_data);
 				let value = if self.omit_value {
-					value.is_some().then_some(OMMIT_VALUE_HASH)
+					value.is_some().then_some(OMIT_VALUE_HASH)
 				} else {
 					value.as_ref().map(|v| v.build(node_data))
 				};

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -99,24 +99,14 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 	/// Generates the encoding of the subtrie rooted at this entry.
 	fn encode_node(&mut self) -> Result<Vec<u8>, C::HashOut, C::Error> {
 		let node_data = self.node.data();
-		let mut modified_node_plan;
-		let node_plan = if self.omit_value {
-			modified_node_plan = self.node.node_plan().clone();
-			if let Some(value) = modified_node_plan.value_plan_mut() {
-				// 0 length value.
-				*value = ValuePlan::Inline(0..0);
-			}
-			&modified_node_plan
-		} else {
-			self.node.node_plan()
-		};
+		let node_plan = self.node.node_plan();
 		let mut encoded = match node_plan {
 			NodePlan::Empty => node_data.to_vec(),
-			NodePlan::Leaf { partial, value } =>
+			NodePlan::Leaf { partial, value: _ } =>
 				if self.omit_value {
 					let partial = partial.build(node_data);
-					let value = value.build(node_data);
-					C::leaf_node(partial.right_iter(), partial.len(), value)
+					let no_value = crate::node::Value::Inline(&[]);
+					C::leaf_node(partial.right_iter(), partial.len(), no_value)
 				} else {
 					node_data.to_vec()
 				},
@@ -128,17 +118,29 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 					let empty_child = ChildReference::Inline(C::HashOut::default(), 0);
 					C::extension_node(partial.right_iter(), partial.len(), empty_child)
 				},
-			NodePlan::Branch { value, children } => C::branch_node(
-				Self::branch_children(node_data, &children, &self.omit_children)?.iter(),
-				value.as_ref().map(|v| v.build(node_data)),
-			),
+			NodePlan::Branch { value, children } => {
+				let value = if self.omit_value {
+					value.as_ref().map(|_v| crate::node::Value::Inline(&[]))
+				} else {
+					value.as_ref().map(|v| v.build(node_data))
+				};
+				C::branch_node(
+					Self::branch_children(node_data, &children, &self.omit_children)?.iter(),
+					value,
+				)
+			},
 			NodePlan::NibbledBranch { partial, value, children } => {
 				let partial = partial.build(node_data);
+				let value = if self.omit_value {
+					value.as_ref().map(|_v| crate::node::Value::Inline(&[]))
+				} else {
+					value.as_ref().map(|v| v.build(node_data))
+				};
 				C::branch_node_nibbled(
 					partial.right_iter(),
 					partial.len(),
 					Self::branch_children(node_data, &children, &self.omit_children)?.iter(),
-					value.as_ref().map(|v| v.build(node_data)),
+					value,
 				)
 			},
 		};

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -34,6 +34,8 @@ use crate::{
 };
 use hash_db::{HashDB, Prefix};
 
+const OMMIT_VALUE_HASH: crate::node::Value<'static> = crate::node::Value::Inline(&[]);
+
 struct EncoderStackEntry<C: NodeCodec> {
 	/// The prefix is the nibble path to the node in the trie.
 	prefix: NibbleVec,
@@ -105,8 +107,7 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 			NodePlan::Leaf { partial, value: _ } =>
 				if self.omit_value {
 					let partial = partial.build(node_data);
-					let no_value = crate::node::Value::Inline(&[]);
-					C::leaf_node(partial.right_iter(), partial.len(), no_value)
+					C::leaf_node(partial.right_iter(), partial.len(), OMMIT_VALUE_HASH)
 				} else {
 					node_data.to_vec()
 				},
@@ -120,7 +121,7 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 				},
 			NodePlan::Branch { value, children } => {
 				let value = if self.omit_value {
-					value.as_ref().map(|_v| crate::node::Value::Inline(&[]))
+					value.is_some().then_some(OMMIT_VALUE_HASH)
 				} else {
 					value.as_ref().map(|v| v.build(node_data))
 				};
@@ -132,7 +133,7 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 			NodePlan::NibbledBranch { partial, value, children } => {
 				let partial = partial.build(node_data);
 				let value = if self.omit_value {
-					value.as_ref().map(|_v| crate::node::Value::Inline(&[]))
+					value.is_some().then_some(OMMIT_VALUE_HASH)
 				} else {
 					value.as_ref().map(|v| v.build(node_data))
 				};


### PR DESCRIPTION
While working on  https://github.com/cheme/trie/tree/proof_size_tracking, I found that for leaf the hash of detached value was kept in proof.
This pr remove it.
On decode we still overwrite the hash the same way, so this should not need any specific client upgrade (could be an idea later to drop on hash present when it is included in next proof item).
Note that the code is correct for branch already.