### PR TITLE
switch no_std map to btreemap

### DIFF
--- a/hash-db/CHANGELOG.md
+++ b/hash-db/CHANGELOG.md
@@ -5,3 +5,5 @@ The format is based on [Keep a Changelog].
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
+
+- Requires Hash to be Ord.

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -32,6 +32,15 @@ pub trait MaybeDebug {}
 #[cfg(not(feature = "std"))]
 impl<T> MaybeDebug for T {}
 
+#[cfg(not(feature = "std"))]
+pub trait MaybeOrd: core::cmp::Ord {}
+#[cfg(not(feature = "std"))]
+impl<T: core::cmp::Ord> MaybeOrd for T {}
+#[cfg(feature = "std")]
+pub trait MaybeOrd {}
+#[cfg(feature = "std")]
+impl<T> MaybeOrd for T {}
+
 /// A trie node prefix, it is the nibble path from the trie root
 /// to the trie node.
 /// For a node containing no partial key value it is the full key.
@@ -56,6 +65,7 @@ pub trait Hasher: Sync + Send {
 		+ AsMut<[u8]>
 		+ Default
 		+ MaybeDebug
+		+ MaybeOrd
 		+ PartialEq
 		+ Eq
 		+ hash::Hash

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -32,15 +32,6 @@ pub trait MaybeDebug {}
 #[cfg(not(feature = "std"))]
 impl<T> MaybeDebug for T {}
 
-#[cfg(not(feature = "std"))]
-pub trait MaybeOrd: core::cmp::Ord {}
-#[cfg(not(feature = "std"))]
-impl<T: core::cmp::Ord> MaybeOrd for T {}
-#[cfg(feature = "std")]
-pub trait MaybeOrd {}
-#[cfg(feature = "std")]
-impl<T> MaybeOrd for T {}
-
 /// A trie node prefix, it is the nibble path from the trie root
 /// to the trie node.
 /// For a node containing no partial key value it is the full key.
@@ -65,7 +56,7 @@ pub trait Hasher: Sync + Send {
 		+ AsMut<[u8]>
 		+ Default
 		+ MaybeDebug
-		+ MaybeOrd
+		+ core::cmp::Ord
 		+ PartialEq
 		+ Eq
 		+ hash::Hash

--- a/memory-db/CHANGELOG.md
+++ b/memory-db/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+- Switch no_std storage to BtreeMap.
+
 ## [0.31.0] - 2022-11-29
 - Removed `parity-util-mem` support. [#172](https://github.com/paritytech/trie/pull/172)
 

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 
 [dependencies]
 hash-db = { version = "0.15.2", path = "../hash-db", default-features = false }
-hashbrown = { version = "0.13.2", default-features = false, features = [ "ahash" ] }
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher" }

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -20,7 +20,8 @@
 extern crate alloc;
 
 use hash_db::{
-	AsHashDB, AsPlainDB, HashDB, HashDBRef, Hasher as KeyHasher, PlainDB, PlainDBRef, Prefix, MaybeOrd, MaybeDebug,
+	AsHashDB, AsPlainDB, HashDB, HashDBRef, Hasher as KeyHasher, MaybeDebug, MaybeOrd, PlainDB,
+	PlainDBRef, Prefix,
 };
 #[cfg(feature = "std")]
 use std::{

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -20,8 +20,8 @@
 extern crate alloc;
 
 use hash_db::{
-	AsHashDB, AsPlainDB, HashDB, HashDBRef, Hasher as KeyHasher, MaybeDebug, MaybeOrd, PlainDB,
-	PlainDBRef, Prefix,
+	AsHashDB, AsPlainDB, HashDB, HashDBRef, Hasher as KeyHasher, MaybeDebug, PlainDB, PlainDBRef,
+	Prefix,
 };
 #[cfg(feature = "std")]
 use std::{
@@ -134,7 +134,7 @@ where
 }
 
 pub trait KeyFunction<H: KeyHasher> {
-	type Key: Send + Sync + Clone + hash::Hash + Eq + MaybeDebug + MaybeOrd;
+	type Key: Send + Sync + Clone + hash::Hash + Eq + MaybeDebug + core::cmp::Ord;
 
 	fn key(hash: &H::Out, prefix: Prefix) -> Self::Key;
 }


### PR DESCRIPTION
This PR switch memorydb to use btreemap internally when used with no_std.
Additionally constrain the Hash of the Hasher to be Ord.