### PR TITLE
prepare crate release

### DIFF
--- a/hash-db/CHANGELOG.md
+++ b/hash-db/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [Unreleased]
+## [0.16.0] - 2023-03-14
+- Requires Hash to be Ord. [#188](https://github.com/paritytech/trie/pull/188)
 
-- Requires Hash to be Ord.
+

--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-db"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Trait for hash-keyed databases."
 license = "Apache-2.0"

--- a/memory-db/CHANGELOG.md
+++ b/memory-db/CHANGELOG.md
@@ -4,9 +4,8 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [Unreleased]
-
-- Switch no_std storage to BtreeMap.
+## [0.32.0] - 2023-03-14
+- Switch no_std storage to BtreeMap. [#188](https://github.com/paritytech/trie/pull/188)
 
 ## [0.31.0] - 2022-11-29
 - Removed `parity-util-mem` support. [#172](https://github.com/paritytech/trie/pull/172)

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-db"
-version = "0.31.0"
+version = "0.32.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory implementation of hash-db, useful for tests"
 repository = "https://github.com/paritytech/trie"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-hash-db = { version = "0.15.2", path = "../hash-db", default-features = false }
+hash-db = { version = "0.16.0", path = "../hash-db", default-features = false }
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher" }

--- a/test-support/keccak-hasher/CHANGELOG.md
+++ b/test-support/keccak-hasher/CHANGELOG.md
@@ -4,7 +4,8 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [Unreleased]
+## [0.16.0] - 2023-03-14
+- Switch to `hash-db` 0.16. [#188](https://github.com/paritytech/trie/pull/188)
 
 ## [0.15.3] - 2020-07-24
 - Update `tiny-keccak` to 0.2. [#105](https://github.com/paritytech/trie/pull/105)

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keccak-hasher"
-version = "0.15.3"
+version = "0.16.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Keccak-256 implementation of the Hasher trait"
 repository = "https://github.com/paritytech/parity/"
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-hash-db = { path = "../../hash-db", default-features = false, version = "0.15.2" }
+hash-db = { path = "../../hash-db", default-features = false, version = "0.16.0" }
 hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 
 [features]

--- a/test-support/reference-trie/CHANGELOG.md
+++ b/test-support/reference-trie/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+
+## [0.29.0] - 2023-03-14
+- Update dependenies. [#188](https://github.com/paritytech/trie/pull/188) and [#187](https://github.com/paritytech/trie/pull/187)
+
 ## [0.26.0] - 2022-08-04
 - Update trie-db to 0.24.0. [#163](https://github.com/paritytech/trie/pull/163)
 

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"
@@ -8,10 +8,10 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-hash-db = { path = "../../hash-db" , version = "0.15.2"}
-keccak-hasher = { path = "../keccak-hasher", version = "0.15.3" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.26.0" }
-trie-root = { path = "../../trie-root", default-features = false, version = "0.17.0" }
+hash-db = { path = "../../hash-db" , version = "0.16.0"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.16.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.27.0" }
+trie-root = { path = "../../trie-root", default-features = false, version = "0.18.0" }
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 hashbrown = { version = "0.13.2", default-features = false, features = ["ahash"] }
 

--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.37.0] - 2023-03-14
+- Update dependenies. [#188](https://github.com/paritytech/trie/pull/188) and [#187](https://github.com/paritytech/trie/pull/187)
+
 ## [0.36.0] - 2023-02-24
 - Updated `trie-db` to 0.26.0. [#185](https://github.com/paritytech/trie/pull/185)
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.36.0"
+version = "0.37.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.15.2" }
-trie-standardmap = { path = "../trie-standardmap", version = "0.15.2" }
-hash-db = { path = "../../hash-db" , version = "0.15.2"}
-memory-db = { path = "../../memory-db", version = "0.31.0" }
-trie-root = { path = "../../trie-root", version = "0.17.0" }
-trie-db = { path = "../../trie-db", version = "0.26.0" }
+keccak-hasher = { path = "../keccak-hasher", version = "0.16.0" }
+trie-standardmap = { path = "../trie-standardmap", version = "0.16.0" }
+hash-db = { path = "../../hash-db" , version = "0.16.0"}
+memory-db = { path = "../../memory-db", version = "0.32.0" }
+trie-root = { path = "../../trie-root", version = "0.18.0" }
+trie-db = { path = "../../trie-db", version = "0.27.0" }
 criterion = "0.4.0"
 parity-scale-codec = "3.0.0"

--- a/test-support/trie-standardmap/CHANGELOG.md
+++ b/test-support/trie-standardmap/CHANGELOG.md
@@ -4,4 +4,5 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [Unreleased]
+## [0.16.0] - 2023-03-14
+- Update dependenies. [#188](https://github.com/paritytech/trie/pull/188) and [#187](https://github.com/paritytech/trie/pull/187)

--- a/test-support/trie-standardmap/Cargo.toml
+++ b/test-support/trie-standardmap/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "trie-standardmap"
 description = "Standard test map for profiling tries"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-keccak-hasher = { path = "../keccak-hasher", version = "0.15.2"}
-hash-db = { path = "../../hash-db" , version = "0.15.2"}
+keccak-hasher = { path = "../keccak-hasher", version = "0.16.0"}
+hash-db = { path = "../../hash-db" , version = "0.16.0"}

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -4,9 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## [Unreleased]
-
+## [0.27.0] - 2023-03-14
 - Fix compact proof to skip including value node hashes [#187](https://github.com/paritytech/trie/pull/187)
+- Update dependenies. [#188](https://github.com/paritytech/trie/pull/188)
 
 ## [0.26.0] - 2023-02-24
 - `TrieDBRawIterator` and `TrieDBNodeIterator` now return a node inside of an `Arc` instead of `Rc` [#185](https://github.com/paritytech/trie/pull/185)

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 smallvec = { version = "1.0.0", features = ["union", "const_new"] }
-hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.16.0"}
 hashbrown = { version = "0.13.2", default-features = false, features = ["ahash"] }
 rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 

--- a/trie-db/fuzz/Cargo.toml
+++ b/trie-db/fuzz/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-hash-db = { path = "../../hash-db", version = "0.15.2" }
-memory-db = { path = "../../memory-db", version = "0.31.0" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.28.0" }
+hash-db = { path = "../../hash-db", version = "0.16.0" }
+memory-db = { path = "../../memory-db", version = "0.32.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }
 
 [dependencies.trie-db]
 path = ".."

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db-test"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-db crate"
 repository = "https://github.com/paritytech/trie"
@@ -12,12 +12,12 @@ name = "bench"
 harness = false
 
 [dependencies]
-trie-db = { path = "..", version = "0.26.0"}
-hash-db = { path = "../../hash-db", version = "0.15.2"}
-memory-db = { path = "../../memory-db", version = "0.31.0" }
+trie-db = { path = "..", version = "0.27.0"}
+hash-db = { path = "../../hash-db", version = "0.16.0"}
+memory-db = { path = "../../memory-db", version = "0.32.0" }
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
-trie-standardmap = { path = "../../test-support/trie-standardmap", version = "0.15.2" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.28.0" }
+trie-standardmap = { path = "../../test-support/trie-standardmap", version = "0.16.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }
 hex-literal = "0.3"
 criterion = "0.4.0"
 env_logger = { version = "0.10", default-features = false }

--- a/trie-eip1186/Cargo.toml
+++ b/trie-eip1186/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-eip1186"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "EIP-1186 compliant proof generation and verification"
 repository = "https://github.com/paritytech/trie"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-db = { path = "../trie-db", default-features = false, version = "0.26.0"}
-hash-db = { path = "../hash-db", default-features = false, version = "0.15.2"}
+trie-db = { path = "../trie-db", default-features = false, version = "0.27.0"}
+hash-db = { path = "../hash-db", default-features = false, version = "0.16.0"}
 
 [features]
 default = ["std"]

--- a/trie-eip1186/test/Cargo.toml
+++ b/trie-eip1186/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-eip1186-test"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-eip1186 crate"
 repository = "https://github.com/paritytech/trie"
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-eip1186 = { path = "..", version = "0.4.0"}
-trie-db = { path = "../../trie-db", version = "0.26.0"}
-hash-db = { path = "../../hash-db", version = "0.15.2"}
-reference-trie = { path = "../../test-support/reference-trie", version = "0.28.0" }
-memory-db = { path = "../../memory-db", version = "0.31.0" }
+trie-eip1186 = { path = "..", version = "0.5.0"}
+trie-db = { path = "../../trie-db", version = "0.27.0"}
+hash-db = { path = "../../hash-db", version = "0.16.0"}
+reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }
+memory-db = { path = "../../memory-db", version = "0.32.0" }

--- a/trie-root/CHANGELOG.md
+++ b/trie-root/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+
+## [0.18.0] - 2023-03-14
+- Update dependenies. [#188](https://github.com/paritytech/trie/pull/188) and [#187](https://github.com/paritytech/trie/pull/187)
+
 ## [0.17.0] - 2021-10-19
 - Support for value nodes. [#142](https://github.com/paritytech/trie/pull/142)
 

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "In-memory patricia trie operations"
 repository = "https://github.com/paritytech/trie"
@@ -9,7 +9,7 @@ categories = [ "no-std" ]
 edition = "2018"
 
 [dependencies]
-hash-db = { path = "../hash-db", default-features = false, version = "0.15.2" }
+hash-db = { path = "../hash-db", default-features = false, version = "0.16.0" }
 
 [features]
 default = ["std"]

--- a/trie-root/test/Cargo.toml
+++ b/trie-root/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-root-test"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests fo trie-root crate"
 repository = "https://github.com/paritytech/trie"
@@ -9,7 +9,7 @@ categories = [ ]
 edition = "2018"
 
 [dependencies]
-trie-root = { path = "..", version = "0.17.0" }
+trie-root = { path = "..", version = "0.18.0" }
 hex-literal = "0.3"
-keccak-hasher = { path = "../../test-support/keccak-hasher", version = "0.15.2" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.28.0" }
+keccak-hasher = { path = "../../test-support/keccak-hasher", version = "0.16.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }


### PR DESCRIPTION
This PR prepare crate release for:
hash-db 0.16.0
memory-db 0.32.0
keccak-hasher 0.16.0
reference-trie 0.29.0
trie-bench 0.37.0
trie-standardmap 0.16.0
trie-db 0.27.0
trie-root 0.18.0