### PR TITLE
Make `trie_nodes_recorded_for_key` work for inline values

### DIFF
--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -173,6 +173,13 @@ pub enum TrieAccess<'a, H> {
 	///
 	/// Should map to [`RecordedForKey::Value`] when checking the recorder.
 	Value { hash: H, value: rstd::borrow::Cow<'a, [u8]>, full_key: &'a [u8] },
+	/// A value was accessed that is stored inline a node.
+	///
+	/// As the value is stored inline there is no need to separately record the value as it is part
+	/// of a node. The given `full_key` is the key to access this value in the trie.
+	///
+	/// Should map to [`RecordedForKey::Value`] when checking the recorder.
+	InlineValue { full_key: &'a [u8] },
 	/// The hash of the value for the given `full_key` was accessed.
 	///
 	/// Should map to [`RecordedForKey::Hash`] when checking the recorder.
@@ -184,7 +191,7 @@ pub enum TrieAccess<'a, H> {
 }
 
 /// Result of [`TrieRecorder::trie_nodes_recorded_for_key`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RecordedForKey {
 	/// We recorded all trie nodes up to the value for a storage key.
 	///

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -402,6 +402,9 @@ where
 					Ok(match v {
 						Value::Inline(v) => {
 							if let Some(recoder) = recorder.as_mut() {
+								// We can record this as `InlineValue`, even we are just returning
+								// the `hash`. This is done to prevent requiring to re-record this
+								// key.
 								recoder.record(TrieAccess::InlineValue { full_key });
 							}
 
@@ -452,6 +455,9 @@ where
 				|value, _, full_key, _, _, recorder| match value {
 					ValueOwned::Inline(value, hash) => {
 						if let Some(recoder) = recorder.as_mut() {
+							// We can record this as `InlineValue`, even we are just returning
+							// the `hash`. This is done to prevent requiring to re-record this
+							// key.
 							recoder.record(TrieAccess::InlineValue { full_key });
 						}
 

--- a/trie-db/src/recorder.rs
+++ b/trie-db/src/recorder.rs
@@ -75,7 +75,7 @@ impl<L: TrieLayout> TrieRecorder<TrieHash<L>> for Recorder<L> {
 			},
 			TrieAccess::InlineValue { full_key } => {
 				self.recorded_keys.entry(full_key.to_vec()).insert(RecordedForKey::Value);
-			}
+			},
 		}
 	}
 

--- a/trie-db/src/recorder.rs
+++ b/trie-db/src/recorder.rs
@@ -71,8 +71,11 @@ impl<L: TrieLayout> TrieRecorder<TrieHash<L>> for Recorder<L> {
 			},
 			TrieAccess::NonExisting { full_key } => {
 				// We handle the non existing value/hash like having recorded the value.
-				self.recorded_keys.entry(full_key.to_vec()).insert(RecordedForKey::Value);
+				self.recorded_keys.entry(full_key.to_vec()).insert(RecordedForKey::None);
 			},
+			TrieAccess::InlineValue { full_key } => {
+				self.recorded_keys.entry(full_key.to_vec()).insert(RecordedForKey::Value);
+			}
 		}
 	}
 

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -120,7 +120,7 @@ impl<L: TrieLayout> From<(Bytes, Option<u32>)> for Value<L> {
 	fn from((v, threshold): (Bytes, Option<u32>)) -> Self {
 		match v {
 			value =>
-				if threshold.map(|threshold| value.len() >= threshold as usize).unwrap_or(false) {
+				if threshold.map_or(false, |threshold| value.len() >= threshold as usize) {
 					Value::NewNode(None, value)
 				} else {
 					Value::Inline(value)


### PR DESCRIPTION
`trie_nodes_recorded_for_key` was not working properly for inline values. It would always return `RecordedForKey::None` while we actually have accessed and recorded all the trie nodes for the value. The pr introduces `TrieAccess::InlineValue` to communicate this access to the recorder properly to make it then return `RecordedForKey::Value`.