### PR TITLE
trie-db: Fetch the closest merkle value

### DIFF
--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use hash_db::{HashDBRef, Hasher};
 
-use crate::{rstd::boxed::Box, TrieDBBuilder};
+use crate::{rstd::boxed::Box, MerkleValue, TrieDBBuilder};
 
 /// A `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
 /// Additionaly it stores inserted hash-key mappings for later retrieval.
@@ -75,7 +75,7 @@ where
 	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
-	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
+	) -> Result<Option<MerkleValue<TrieHash<L>>>, TrieHash<L>, CError<L>> {
 		self.raw.lookup_first_descendant(key)
 	}
 

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -72,11 +72,11 @@ where
 		self.raw.get_with(L::Hash::hash(key).as_ref(), query)
 	}
 
-	fn get_closest_merkle_value(
+	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		self.raw.get_closest_merkle_value(key)
+		self.raw.lookup_first_descendant(key)
 	}
 
 	fn iter<'a>(

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -72,6 +72,13 @@ where
 		self.raw.get_with(L::Hash::hash(key).as_ref(), query)
 	}
 
+	fn get_closest_merkle_value(
+		&self,
+		_key: &[u8],
+	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
+		Ok(None)
+	}
+
 	fn iter<'a>(
 		&'a self,
 	) -> Result<

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -74,9 +74,9 @@ where
 
 	fn get_closest_merkle_value(
 		&self,
-		_key: &[u8],
+		key: &[u8],
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		Ok(None)
+		self.raw.get_closest_merkle_value(key)
 	}
 
 	fn iter<'a>(

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -277,6 +277,12 @@ pub trait Trie<L: TrieLayout> {
 		query: Q,
 	) -> Result<Option<Q::Item>, TrieHash<L>, CError<L>>;
 
+	/// Returns the merkle value of the closest descendant node of the key.
+	fn get_closest_merkle_value(
+		&self,
+		key: &[u8],
+	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>>;
+
 	/// Returns a depth-first iterator over the elements of trie.
 	fn iter<'a>(
 		&'a self,
@@ -402,6 +408,13 @@ impl<'db, 'cache, L: TrieLayout> Trie<L> for TrieKinds<'db, 'cache, L> {
 		query: Q,
 	) -> Result<Option<Q::Item>, TrieHash<L>, CError<L>> {
 		wrapper!(self, get_with, key, query)
+	}
+
+	fn get_closest_merkle_value(
+		&self,
+		key: &[u8],
+	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
+		wrapper!(self, get_closest_merkle_value, key)
 	}
 
 	fn iter<'a>(

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -277,8 +277,13 @@ pub trait Trie<L: TrieLayout> {
 		query: Q,
 	) -> Result<Option<Q::Item>, TrieHash<L>, CError<L>>;
 
-	/// Returns the merkle value of the closest descendant node of the key.
-	fn get_closest_merkle_value(
+	/// Look up the merkle value of the node that is the closest descendant for the provided
+	/// key.
+	///
+	/// When the provided key leads to a node, then the merkle value of that node
+	/// is returned. However, if the key does not lead to a node, then the merkle value
+	/// of the closest descendant is returned. `None` if no such descendant exists.
+	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>>;
@@ -410,11 +415,11 @@ impl<'db, 'cache, L: TrieLayout> Trie<L> for TrieKinds<'db, 'cache, L> {
 		wrapper!(self, get_with, key, query)
 	}
 
-	fn get_closest_merkle_value(
+	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		wrapper!(self, get_closest_merkle_value, key)
+		wrapper!(self, lookup_first_descendant, key)
 	}
 
 	fn iter<'a>(

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -286,7 +286,7 @@ pub trait Trie<L: TrieLayout> {
 	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
-	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>>;
+	) -> Result<Option<MerkleValue<TrieHash<L>>>, TrieHash<L>, CError<L>>;
 
 	/// Returns a depth-first iterator over the elements of trie.
 	fn iter<'a>(
@@ -418,7 +418,7 @@ impl<'db, 'cache, L: TrieLayout> Trie<L> for TrieKinds<'db, 'cache, L> {
 	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
-	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
+	) -> Result<Option<MerkleValue<TrieHash<L>>>, TrieHash<L>, CError<L>> {
 		wrapper!(self, lookup_first_descendant, key)
 	}
 
@@ -755,4 +755,16 @@ impl From<Bytes> for BytesWeak {
 	fn from(bytes: Bytes) -> Self {
 		Self(rstd::sync::Arc::downgrade(&bytes.0))
 	}
+}
+
+/// A value returned by [`Trie::lookup_first_descendant`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MerkleValue<H> {
+	/// The merkle value is the node data itself when the
+	/// node data is smaller than `MAX_INLINE_VALUE`.
+	///
+	/// Note: The case of inline nodes.
+	Node(Vec<u8>),
+	/// The merkle value is the hash of the node.
+	Hash(H),
 }

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -757,7 +757,9 @@ impl From<Bytes> for BytesWeak {
 	}
 }
 
-/// A value returned by [`Trie::lookup_first_descendant`].
+/// Either the `hash` or `value` of a node depending on its size.
+///
+/// If the size of the node `value` is bigger or equal than `MAX_INLINE_VALUE` the `hash` is returned.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MerkleValue<H> {
 	/// The merkle value is the node data itself when the

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -277,7 +277,7 @@ pub trait Trie<L: TrieLayout> {
 		query: Q,
 	) -> Result<Option<Q::Item>, TrieHash<L>, CError<L>>;
 
-	/// Look up the merkle value of the node that is the closest descendant for the provided
+	/// Look up the [`MerkleValue`] of the node that is the closest descendant for the provided
 	/// key.
 	///
 	/// When the provided key leads to a node, then the merkle value of that node

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -759,7 +759,8 @@ impl From<Bytes> for BytesWeak {
 
 /// Either the `hash` or `value` of a node depending on its size.
 ///
-/// If the size of the node `value` is bigger or equal than `MAX_INLINE_VALUE` the `hash` is returned.
+/// If the size of the node `value` is bigger or equal than `MAX_INLINE_VALUE` the `hash` is
+/// returned.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MerkleValue<H> {
 	/// The merkle value is the node data itself when the

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -18,7 +18,7 @@ use crate::{
 	nibble::NibbleSlice,
 	node::{decode_hash, Node, NodeHandle, NodeHandleOwned, NodeOwned, Value, ValueOwned},
 	node_codec::NodeCodec,
-	rstd::boxed::Box,
+	rstd::{boxed::Box, vec::Vec},
 	Bytes, CError, CachedValue, DBValue, Query, RecordedForKey, Result, TrieAccess, TrieCache,
 	TrieError, TrieHash, TrieLayout, TrieRecorder,
 };

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -725,27 +725,26 @@ where
 						return Ok(Some(hash))
 					},
 					Node::Extension(slice, item) => {
-						let common_prefix_len = partial.common_prefix(&slice);
-
 						if partial.len() < slice.len() {
+							self.record(|| TrieAccess::NonExisting { full_key });
+
 							// Extension slice can be longer than remainder of the provided key
 							// (descendent), ensure the extension slice starts with the remainder
 							// of the provided key.
-							if common_prefix_len == partial.len() {
-								return Ok(Some(hash))
+							return if slice.starts_with(&partial) {
+								Ok(Some(hash))
 							} else {
-								self.record(|| TrieAccess::NonExisting { full_key });
-								return Ok(None)
+								Ok(None)
 							}
 						}
 
 						// Remainder of the provided key is longer than the extension slice,
 						// must advance the node iteration if and only if keys share
 						// a common prefix.
-						if common_prefix_len == slice.len() {
+						if partial.starts_with(&slice) {
 							// Empties the partial key if the extension slice is longer.
-							partial = partial.mid(common_prefix_len);
-							key_nibbles += common_prefix_len;
+							partial = partial.mid(slice.len());
+							key_nibbles += slice.len();
 							item
 						} else {
 							self.record(|| TrieAccess::NonExisting { full_key });

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -775,27 +775,27 @@ where
 							}
 						},
 					Node::NibbledBranch(slice, children, value) => {
-						let common_prefix_len = partial.common_prefix(&slice);
 						// Not enough remainder key to continue the search.
 						if partial.len() < slice.len() {
 							self.record(|| TrieAccess::NonExisting { full_key });
 
 							// Branch slice starts with the remainder key, there's nothing to
 							// advance.
-							if common_prefix_len == partial.len() {
-								return Ok(Some(hash))
+							return if slice.starts_with(&partial) {
+								Ok(Some(hash))
 							} else {
-								return Ok(None)
+								Ok(None)
 							}
 						}
 
 						// Partial key is longer or equal than the branch slice.
 						// Ensure partial key starts with the branch slice.
-						if common_prefix_len != slice.len() {
+						if !partial.starts_with(&slice) {
 							self.record(|| TrieAccess::NonExisting { full_key });
 							return Ok(None)
 						}
 
+						// Partial key starts with the branch slice.
 						if partial.len() == slice.len() {
 							if value.is_none() {
 								self.record(|| TrieAccess::NonExisting { full_key });

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -669,7 +669,7 @@ where
 		Ok(None)
 	}
 
-	/// Look up the closest merkle value of the provided key.
+	/// Look up the merkle value (hash) of the node that is the closest descendant for the provided key.
 	///
 	/// When the provided key leads to a node, then the merkle value of that node
 	/// is returned. However, if the key does not lead to a node, then the closest

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -134,12 +134,12 @@ where
 		}
 	}
 
-	/// Look up the closest merkle value.
+	/// Look up the closest descendant node.
 	///
-	/// When the provided key leads to a node, then the merkle value of that node
-	/// is returned. However, if the key does not lead to a node, then the closest
-	/// merkle value is returned.
-	pub fn look_up_merkle(
+	/// When the provided key leads to a node, then the hash of the node
+	/// is returned (the merkle value). However, if the key does not lead to a node, then the
+	/// hash of the closest node is returned.
+	pub fn lookup_first_descendant(
 		self,
 		full_key: &[u8],
 		nibble_key: NibbleSlice,

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -711,11 +711,15 @@ where
 
 				let next_node = match decoded {
 					Node::Leaf(slice, _) => {
-						if slice != partial {
+						if partial.starts_with(&slice) {
+							return Ok(Some(hash))
+						}
+
+						if partial.len() != slice.len() {
 							self.record(|| TrieAccess::NonExisting { full_key });
 						}
 
-						return Ok(Some(hash))
+						return Ok(None)
 					},
 					Node::Extension(slice, item) =>
 						if partial.starts_with(&slice) {
@@ -725,7 +729,7 @@ where
 						} else {
 							self.record(|| TrieAccess::NonExisting { full_key });
 
-							return Ok(Some(hash))
+							return Ok(None)
 						},
 					Node::Branch(children, value) =>
 						if partial.is_empty() {
@@ -752,7 +756,7 @@ where
 						if !partial.starts_with(&slice) {
 							self.record(|| TrieAccess::NonExisting { full_key });
 
-							return Ok(Some(hash))
+							return Ok(None)
 						}
 
 						if partial.len() == slice.len() {

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -727,22 +727,22 @@ where
 					Node::Extension(slice, item) => {
 						let common_prefix_len = partial.common_prefix(&slice);
 
-						let start_matches = if partial.len() <= slice.len() {
+						if partial.len() < slice.len() {
 							// Extension slice can be longer than remainder of the provided key
 							// (descendent), ensure the extension slice starts with the remainder
 							// of the provided key.
-							//
-							// This effectively returns the hash of the `Node::Branch` at the next
-							// iteration.
-							common_prefix_len == partial.len()
-						} else {
-							// Remainder of the provided key is longer than the extension slice,
-							// must advance the node iteration if and only if keys share
-							// a common prefix.
-							common_prefix_len == slice.len()
-						};
+							if common_prefix_len == partial.len() {
+								return Ok(Some(hash))
+							} else {
+								self.record(|| TrieAccess::NonExisting { full_key });
+								return Ok(None)
+							}
+						}
 
-						if start_matches {
+						// Remainder of the provided key is longer than the extension slice,
+						// must advance the node iteration if and only if keys share
+						// a common prefix.
+						if common_prefix_len == slice.len() {
 							// Empties the partial key if the extension slice is longer.
 							partial = partial.mid(common_prefix_len);
 							key_nibbles += common_prefix_len;

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -144,7 +144,7 @@ where
 		full_key: &[u8],
 		nibble_key: NibbleSlice,
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		self.look_up_merkle_without_cache(nibble_key, full_key)
+		self.lookup_first_descendent_without_cache(nibble_key, full_key)
 	}
 
 	/// Look up the given `nibble_key`.
@@ -669,12 +669,13 @@ where
 		Ok(None)
 	}
 
-	/// Look up the merkle value (hash) of the node that is the closest descendant for the provided key.
+	/// Look up the merkle value (hash) of the node that is the closest descendant for the provided
+	/// key.
 	///
 	/// When the provided key leads to a node, then the merkle value of that node
 	/// is returned. However, if the key does not lead to a node, then the merkle value
 	/// of the closest descendant is returned. `None` if no such descendant exists.
-	fn look_up_merkle_without_cache(
+	fn lookup_first_descendent_without_cache(
 		mut self,
 		nibble_key: NibbleSlice,
 		full_key: &[u8],

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -711,15 +711,16 @@ where
 
 				let next_node = match decoded {
 					Node::Leaf(slice, _) => {
-						if partial.starts_with(&slice) {
-							return Ok(Some(hash))
+						if !partial.starts_with(&slice) {
+							self.record(|| TrieAccess::NonExisting { full_key });
+							return Ok(None)
 						}
 
 						if partial.len() != slice.len() {
 							self.record(|| TrieAccess::NonExisting { full_key });
 						}
 
-						return Ok(None)
+						return Ok(Some(hash))
 					},
 					Node::Extension(slice, item) =>
 						if partial.starts_with(&slice) {

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -820,7 +820,7 @@ where
 					Node::Empty => {
 						self.record(|| TrieAccess::NonExisting { full_key });
 
-						return Ok(Some(hash))
+						return Ok(None)
 					},
 				};
 

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -672,8 +672,8 @@ where
 	/// Look up the merkle value (hash) of the node that is the closest descendant for the provided key.
 	///
 	/// When the provided key leads to a node, then the merkle value of that node
-	/// is returned. However, if the key does not lead to a node, then the closest
-	/// merkle value is returned.
+	/// is returned. However, if the key does not lead to a node, then the merkle value
+	/// of the closest descendant is returned. `None` if no such descendant exists.
 	fn look_up_merkle_without_cache(
 		mut self,
 		nibble_key: NibbleSlice,

--- a/trie-db/src/nibble/nibblevec.rs
+++ b/trie-db/src/nibble/nibblevec.rs
@@ -235,6 +235,25 @@ impl NibbleVec {
 		true
 	}
 
+	/// Same as [`Self::starts_with`] but using [`NibbleSlice`].
+	pub fn starts_with_slice(&self, other: &NibbleSlice) -> bool {
+		if self.len() < other.len() {
+			return false
+		}
+
+		match self.as_nibbleslice() {
+			Some(slice) => slice.starts_with(&other),
+			None => {
+				for i in 0..other.len() {
+					if self.at(i) != other.at(i) {
+						return false
+					}
+				}
+				true
+			},
+		}
+	}
+
 	/// Return an iterator over `Partial` bytes representation.
 	pub fn right_iter<'a>(&'a self) -> impl Iterator<Item = u8> + 'a {
 		let require_padding = self.len % nibble_ops::NIBBLE_PER_BYTE != 0;

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -75,11 +75,11 @@ where
 		self.raw.get_with(L::Hash::hash(key).as_ref(), query)
 	}
 
-	fn get_closest_merkle_value(
+	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		self.raw.get_closest_merkle_value(key)
+		self.raw.lookup_first_descendant(key)
 	}
 
 	fn iter<'a>(

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -77,9 +77,9 @@ where
 
 	fn get_closest_merkle_value(
 		&self,
-		_key: &[u8],
+		key: &[u8],
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		Ok(None)
+		self.raw.get_closest_merkle_value(key)
 	}
 
 	fn iter<'a>(

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::{
-	rstd::boxed::Box, triedb::TrieDB, CError, DBValue, Query, Result, Trie, TrieDBBuilder,
-	TrieHash, TrieItem, TrieIterator, TrieKeyItem, TrieLayout,
+	rstd::boxed::Box, triedb::TrieDB, CError, DBValue, MerkleValue, Query, Result, Trie,
+	TrieDBBuilder, TrieHash, TrieItem, TrieIterator, TrieKeyItem, TrieLayout,
 };
 use hash_db::{HashDBRef, Hasher};
 
@@ -78,7 +78,7 @@ where
 	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
-	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
+	) -> Result<Option<MerkleValue<TrieHash<L>>>, TrieHash<L>, CError<L>> {
 		self.raw.lookup_first_descendant(key)
 	}
 

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -75,6 +75,13 @@ where
 		self.raw.get_with(L::Hash::hash(key).as_ref(), query)
 	}
 
+	fn get_closest_merkle_value(
+		&self,
+		_key: &[u8],
+	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
+		Ok(None)
+	}
+
 	fn iter<'a>(
 		&'a self,
 	) -> Result<

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -254,9 +254,19 @@ where
 
 	fn get_closest_merkle_value(
 		&self,
-		_key: &[u8],
+		key: &[u8],
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
-		Ok(None)
+		let mut cache = self.cache.as_ref().map(|c| c.borrow_mut());
+		let mut recorder = self.recorder.as_ref().map(|r| r.borrow_mut());
+
+		Lookup::<L, _> {
+			db: self.db,
+			query: |_: &[u8]| (),
+			hash: *self.root,
+			cache: cache.as_mut().map(|c| &mut ***c as &mut dyn TrieCache<L::Codec>),
+			recorder: recorder.as_mut().map(|r| &mut ***r as &mut dyn TrieRecorder<TrieHash<L>>),
+		}
+		.look_up_merkle(key, NibbleSlice::new(key))
 	}
 
 	fn iter<'a>(

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -252,7 +252,7 @@ where
 		.look_up(key, NibbleSlice::new(key))
 	}
 
-	fn get_closest_merkle_value(
+	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
 	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -252,6 +252,13 @@ where
 		.look_up(key, NibbleSlice::new(key))
 	}
 
+	fn get_closest_merkle_value(
+		&self,
+		_key: &[u8],
+	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
+		Ok(None)
+	}
+
 	fn iter<'a>(
 		&'a self,
 	) -> Result<

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -18,8 +18,8 @@ use crate::{
 	nibble::NibbleSlice,
 	node::{decode_hash, NodeHandle, OwnedNode},
 	rstd::boxed::Box,
-	CError, DBValue, Query, Result, Trie, TrieAccess, TrieCache, TrieError, TrieHash, TrieItem,
-	TrieIterator, TrieKeyItem, TrieLayout, TrieRecorder,
+	CError, DBValue, MerkleValue, Query, Result, Trie, TrieAccess, TrieCache, TrieError, TrieHash,
+	TrieItem, TrieIterator, TrieKeyItem, TrieLayout, TrieRecorder,
 };
 #[cfg(feature = "std")]
 use crate::{
@@ -255,7 +255,7 @@ where
 	fn lookup_first_descendant(
 		&self,
 		key: &[u8],
-	) -> Result<Option<TrieHash<L>>, TrieHash<L>, CError<L>> {
+	) -> Result<Option<MerkleValue<TrieHash<L>>>, TrieHash<L>, CError<L>> {
 		let mut cache = self.cache.as_ref().map(|c| c.borrow_mut());
 		let mut recorder = self.recorder.as_ref().map(|r| r.borrow_mut());
 

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -266,7 +266,7 @@ where
 			cache: cache.as_mut().map(|c| &mut ***c as &mut dyn TrieCache<L::Codec>),
 			recorder: recorder.as_mut().map(|r| &mut ***r as &mut dyn TrieRecorder<TrieHash<L>>),
 		}
-		.look_up_merkle(key, NibbleSlice::new(key))
+		.lookup_first_descendant(key, NibbleSlice::new(key))
 	}
 
 	fn iter<'a>(

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -644,78 +644,42 @@ fn test_recorder_with_cache_get_hash_internal<T: TrieLayout>() {
 	}
 }
 
-#[test]
-fn test_merkle_value() {
-	// Use `HashedValueNoExtThreshold` to create a consistent trie with
-	// a smaller dataset for the `key_value`.
-	let mut memdb = MemoryDB::<
-		<HashedValueNoExtThreshold<1> as TrieLayout>::Hash,
-		HashKey<_>,
-		DBValue,
-	>::default();
+test_layouts!(test_merkle_value, test_merkle_value_internal);
+fn test_merkle_value_internal<T: TrieLayout>() {
+	let mut memdb = MemoryDB::<T::Hash, HashKey<_>, DBValue>::default();
 	let mut root = Default::default();
 
 	// Data set.
-	let mut key_value = vec![
+	let key_value = vec![
 		(b"A".to_vec(), vec![1; 64]),
 		(b"AA".to_vec(), vec![2; 64]),
 		(b"AAA".to_vec(), vec![3; 64]),
-		(b"AB".to_vec(), vec![4; 4]),
-		(b"B".to_vec(), vec![5; 64]),
+		(b"AAB".to_vec(), vec![4; 64]),
+		(b"AB".to_vec(), vec![5; 4]),
+		(b"B".to_vec(), vec![6; 64]),
 	];
-
 	{
-		let mut t =
-			TrieDBMutBuilder::<HashedValueNoExtThreshold<1>>::new(&mut memdb, &mut root).build();
+		let mut t = TrieDBMutBuilder::<T>::new(&mut memdb, &mut root).build();
 		for (key, value) in &key_value {
 			t.insert(key, value).unwrap();
 		}
 	}
 
-	let mut merkle_values = Vec::new();
-	let prev_root = root.clone();
-
-	// Fetch merkle values.
-	{
-		let trie = TrieDBBuilder::<HashedValueNoExtThreshold<1>>::new(&memdb, &root).build();
-		for (key, _) in &key_value {
-			let merkle = trie.get_closest_merkle_value(key).unwrap().unwrap();
-			merkle_values.push(merkle);
-		}
+	// Ensure we can fetch the merkle values for all present keys.
+	let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
+	for (key, _) in &key_value {
+		trie.get_closest_merkle_value(key).unwrap().unwrap();
 	}
 
-	// Make a change to AA and expect the change to propagate only to AA and A.
-	{
-		let mut t =
-			TrieDBMutBuilder::<HashedValueNoExtThreshold<1>>::from_existing(&mut memdb, &mut root)
-				.build();
-		key_value[1].1 = vec![6; 64];
-		t.insert(&key_value[1].0, &key_value[1].1).unwrap();
-	}
+	// Key is not present in the trie, but the closest descendant is AAA.
+	let hash = trie.get_closest_merkle_value(b"AAAA").unwrap().unwrap();
+	let expected = trie.get_closest_merkle_value(b"AAA").unwrap().unwrap();
+	assert_eq!(hash, expected);
 
-	// The root should always change.
-	assert_ne!(prev_root, root);
-
-	let mut modified_merkle_values = Vec::new();
-	{
-		let trie = TrieDBBuilder::<HashedValueNoExtThreshold<1>>::new(&memdb, &root).build();
-		for (key, _) in &key_value {
-			let merkle = trie.get_closest_merkle_value(key).unwrap().unwrap();
-			modified_merkle_values.push(merkle);
-		}
-	}
-
-	// A differs.
-	assert_ne!(merkle_values[0], modified_merkle_values[0]);
-	// AA differs.
-	assert_ne!(merkle_values[1], modified_merkle_values[1]);
-
-	// AAA remains the same.
-	assert_eq!(merkle_values[2], modified_merkle_values[2]);
-	// AB remains the same.
-	assert_eq!(merkle_values[3], modified_merkle_values[3]);
-	// B remains the same.
-	assert_eq!(merkle_values[4], modified_merkle_values[4]);
+	// Key is not present in the trie, but the closest descendant is AB.
+	let hash = trie.get_closest_merkle_value(b"ABA").unwrap().unwrap();
+	let expected = trie.get_closest_merkle_value(b"AB").unwrap().unwrap();
+	assert_eq!(hash, expected);
 }
 
 test_layouts!(iterator_seek_with_recorder, iterator_seek_with_recorder_internal);

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -669,45 +669,45 @@ fn test_merkle_value_internal<T: TrieLayout>() {
 	// Ensure we can fetch the merkle values for all present keys.
 	let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
 	for (key, _) in &key_value {
-		trie.get_closest_merkle_value(key).unwrap().unwrap();
+		trie.lookup_first_descendant(key).unwrap().unwrap();
 	}
 
 	// Key is not present and has no descedant, but shares a prefix.
-	let hash = trie.get_closest_merkle_value(b"AAAAX").unwrap();
+	let hash = trie.lookup_first_descendant(b"AAAAX").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"AABX").unwrap();
+	let hash = trie.lookup_first_descendant(b"AABX").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"AABC").unwrap();
+	let hash = trie.lookup_first_descendant(b"AABC").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"ABX").unwrap();
+	let hash = trie.lookup_first_descendant(b"ABX").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"AABBBBX").unwrap();
+	let hash = trie.lookup_first_descendant(b"AABBBBX").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"BX").unwrap();
+	let hash = trie.lookup_first_descendant(b"BX").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"AC").unwrap();
+	let hash = trie.lookup_first_descendant(b"AC").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"BC").unwrap();
+	let hash = trie.lookup_first_descendant(b"BC").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"AAAAX").unwrap();
+	let hash = trie.lookup_first_descendant(b"AAAAX").unwrap();
 	assert!(hash.is_none());
 	// Key shares the first nibble with b"A".
-	let hash = trie.get_closest_merkle_value(b"C").unwrap();
+	let hash = trie.lookup_first_descendant(b"C").unwrap();
 	assert!(hash.is_none());
 
 	// Key not present, but has a descendent.
-	let hash = trie.get_closest_merkle_value(b"AAA").unwrap().unwrap();
-	let expected = trie.get_closest_merkle_value(b"AAAA").unwrap().unwrap();
+	let hash = trie.lookup_first_descendant(b"AAA").unwrap().unwrap();
+	let expected = trie.lookup_first_descendant(b"AAAA").unwrap().unwrap();
 	assert_eq!(hash, expected);
-	let hash = trie.get_closest_merkle_value(b"AABB").unwrap().unwrap();
-	let expected = trie.get_closest_merkle_value(b"AABBBB").unwrap().unwrap();
+	let hash = trie.lookup_first_descendant(b"AABB").unwrap().unwrap();
+	let expected = trie.lookup_first_descendant(b"AABBBB").unwrap().unwrap();
 	assert_eq!(hash, expected);
-	let hash = trie.get_closest_merkle_value(b"AABBB").unwrap().unwrap();
-	let expected = trie.get_closest_merkle_value(b"AABBBB").unwrap().unwrap();
+	let hash = trie.lookup_first_descendant(b"AABBB").unwrap().unwrap();
+	let expected = trie.lookup_first_descendant(b"AABBBB").unwrap().unwrap();
 	assert_eq!(hash, expected);
 
 	// Prefix AABB in between AAB and AABBBB, but has different ending char.
-	let hash = trie.get_closest_merkle_value(b"AABBX").unwrap();
+	let hash = trie.lookup_first_descendant(b"AABBX").unwrap();
 	assert!(hash.is_none());
 }
 
@@ -727,14 +727,14 @@ fn test_merkle_value_single_key_internal<T: TrieLayout>() {
 
 	let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
 
-	let hash = trie.get_closest_merkle_value(b"AA").unwrap().unwrap();
-	let expected = trie.get_closest_merkle_value(b"AAA").unwrap().unwrap();
+	let hash = trie.lookup_first_descendant(b"AA").unwrap().unwrap();
+	let expected = trie.lookup_first_descendant(b"AAA").unwrap().unwrap();
 	assert_eq!(hash, expected);
 
 	// Trie does not contain AAC or AAAA.
-	let hash = trie.get_closest_merkle_value(b"AAC").unwrap();
+	let hash = trie.lookup_first_descendant(b"AAC").unwrap();
 	assert!(hash.is_none());
-	let hash = trie.get_closest_merkle_value(b"AAAA").unwrap();
+	let hash = trie.lookup_first_descendant(b"AAAA").unwrap();
 	assert!(hash.is_none());
 }
 
@@ -755,9 +755,9 @@ fn test_merkle_value_branches_internal<T: TrieLayout>() {
 	let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
 
 	// The hash is returned from the branch node.
-	let hash = trie.get_closest_merkle_value(b"A").unwrap().unwrap();
-	let aaaa_hash = trie.get_closest_merkle_value(b"AAAA").unwrap().unwrap();
-	let aaba_hash = trie.get_closest_merkle_value(b"AABA").unwrap().unwrap();
+	let hash = trie.lookup_first_descendant(b"A").unwrap().unwrap();
+	let aaaa_hash = trie.lookup_first_descendant(b"AAAA").unwrap().unwrap();
+	let aaba_hash = trie.lookup_first_descendant(b"AABA").unwrap().unwrap();
 	// Ensure the hash is not from any leaf.
 	assert_ne!(hash, aaaa_hash);
 	assert_ne!(hash, aaba_hash);
@@ -777,19 +777,19 @@ fn test_merkle_value_empty_trie_internal<T: TrieLayout>() {
 	// Data set is empty.
 	let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
 
-	let hash = trie.get_closest_merkle_value(b"").unwrap();
+	let hash = trie.lookup_first_descendant(b"").unwrap();
 	assert!(hash.is_none());
 
-	let hash = trie.get_closest_merkle_value(b"A").unwrap();
+	let hash = trie.lookup_first_descendant(b"A").unwrap();
 	assert!(hash.is_none());
 
-	let hash = trie.get_closest_merkle_value(b"AA").unwrap();
+	let hash = trie.lookup_first_descendant(b"AA").unwrap();
 	assert!(hash.is_none());
 
-	let hash = trie.get_closest_merkle_value(b"AAA").unwrap();
+	let hash = trie.lookup_first_descendant(b"AAA").unwrap();
 	assert!(hash.is_none());
 
-	let hash = trie.get_closest_merkle_value(b"AAAA").unwrap();
+	let hash = trie.lookup_first_descendant(b"AAAA").unwrap();
 	assert!(hash.is_none());
 }
 
@@ -810,9 +810,9 @@ fn test_merkle_value_modification_internal<T: TrieLayout>() {
 		let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
 
 		// The hash is returned from the branch node.
-		let hash = trie.get_closest_merkle_value(b"A").unwrap().unwrap();
-		let aaaa_hash = trie.get_closest_merkle_value(b"AAAA").unwrap().unwrap();
-		let aaba_hash = trie.get_closest_merkle_value(b"AABA").unwrap().unwrap();
+		let hash = trie.lookup_first_descendant(b"A").unwrap().unwrap();
+		let aaaa_hash = trie.lookup_first_descendant(b"AAAA").unwrap().unwrap();
+		let aaba_hash = trie.lookup_first_descendant(b"AABA").unwrap().unwrap();
 
 		// Ensure the hash is not from any leaf.
 		assert_ne!(hash, aaaa_hash);
@@ -831,9 +831,9 @@ fn test_merkle_value_modification_internal<T: TrieLayout>() {
 		let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
 
 		// The hash is returned from the branch node.
-		let hash = trie.get_closest_merkle_value(b"A").unwrap().unwrap();
-		let aaaa_hash = trie.get_closest_merkle_value(b"AAAA").unwrap().unwrap();
-		let aaba_hash = trie.get_closest_merkle_value(b"AABA").unwrap().unwrap();
+		let hash = trie.lookup_first_descendant(b"A").unwrap().unwrap();
+		let aaaa_hash = trie.lookup_first_descendant(b"AAAA").unwrap().unwrap();
+		let aaba_hash = trie.lookup_first_descendant(b"AABA").unwrap().unwrap();
 
 		// Ensure the hash is not from any leaf.
 		assert_ne!(hash, aaaa_hash);

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -759,6 +759,36 @@ fn test_merkle_value_branches_internal<T: TrieLayout>() {
 	assert_ne!(hash, aaba_hash);
 }
 
+test_layouts!(test_merkle_value_empty_trie, test_merkle_value_empty_trie_internal);
+fn test_merkle_value_empty_trie_internal<T: TrieLayout>() {
+	let mut memdb = MemoryDB::<T::Hash, PrefixedKey<_>, DBValue>::default();
+	let mut root = Default::default();
+
+	{
+		// Valid state root.
+		let mut t = TrieDBMutBuilder::<T>::new(&mut memdb, &mut root).build();
+		t.insert(&[], &[]).unwrap();
+	}
+
+	// Data set is empty.
+	let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
+
+	let hash = trie.get_closest_merkle_value(b"").unwrap();
+	assert!(hash.is_none());
+
+	let hash = trie.get_closest_merkle_value(b"A").unwrap();
+	assert!(hash.is_none());
+
+	let hash = trie.get_closest_merkle_value(b"AA").unwrap();
+	assert!(hash.is_none());
+
+	let hash = trie.get_closest_merkle_value(b"AAA").unwrap();
+	assert!(hash.is_none());
+
+	let hash = trie.get_closest_merkle_value(b"AAAA").unwrap();
+	assert!(hash.is_none());
+}
+
 test_layouts!(test_merkle_value_modification, test_merkle_value_modification_internal);
 fn test_merkle_value_modification_internal<T: TrieLayout>() {
 	let mut memdb = MemoryDB::<T::Hash, PrefixedKey<_>, DBValue>::default();

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -677,11 +677,15 @@ fn test_merkle_value_internal<T: TrieLayout>() {
 	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"AABX").unwrap();
 	assert!(hash.is_none());
+	let hash = trie.get_closest_merkle_value(b"AABC").unwrap();
+	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"ABX").unwrap();
 	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"AABBBBX").unwrap();
 	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"BX").unwrap();
+	assert!(hash.is_none());
+	let hash = trie.get_closest_merkle_value(b"BC").unwrap();
 	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"AAAAX").unwrap();
 	assert!(hash.is_none());

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -646,7 +646,7 @@ fn test_recorder_with_cache_get_hash_internal<T: TrieLayout>() {
 
 test_layouts!(test_merkle_value, test_merkle_value_internal);
 fn test_merkle_value_internal<T: TrieLayout>() {
-	let mut memdb = MemoryDB::<T::Hash, HashKey<_>, DBValue>::default();
+	let mut memdb = MemoryDB::<T::Hash, PrefixedKey<_>, DBValue>::default();
 	let mut root = Default::default();
 
 	// Data set.
@@ -707,7 +707,7 @@ fn test_merkle_value_internal<T: TrieLayout>() {
 
 test_layouts!(test_merkle_value_single_key, test_merkle_value_single_key_internal);
 fn test_merkle_value_single_key_internal<T: TrieLayout>() {
-	let mut memdb = MemoryDB::<T::Hash, HashKey<_>, DBValue>::default();
+	let mut memdb = MemoryDB::<T::Hash, PrefixedKey<_>, DBValue>::default();
 	let mut root = Default::default();
 
 	// Data set.
@@ -732,7 +732,7 @@ fn test_merkle_value_single_key_internal<T: TrieLayout>() {
 
 test_layouts!(test_merkle_value_branches, test_merkle_value_branches_internal);
 fn test_merkle_value_branches_internal<T: TrieLayout>() {
-	let mut memdb = MemoryDB::<T::Hash, HashKey<_>, DBValue>::default();
+	let mut memdb = MemoryDB::<T::Hash, PrefixedKey<_>, DBValue>::default();
 	let mut root = Default::default();
 
 	// Data set.
@@ -757,7 +757,7 @@ fn test_merkle_value_branches_internal<T: TrieLayout>() {
 
 test_layouts!(test_merkle_value_modification, test_merkle_value_modification_internal);
 fn test_merkle_value_modification_internal<T: TrieLayout>() {
-	let mut memdb = MemoryDB::<T::Hash, HashKey<_>, DBValue>::default();
+	let mut memdb = MemoryDB::<T::Hash, PrefixedKey<_>, DBValue>::default();
 	let mut root = Default::default();
 
 	let key_value = vec![(b"AAAA".to_vec(), vec![1; 64]), (b"AABA".to_vec(), vec![2; 64])];

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -680,6 +680,20 @@ fn test_merkle_value_internal<T: TrieLayout>() {
 	let hash = trie.get_closest_merkle_value(b"ABA").unwrap().unwrap();
 	let expected = trie.get_closest_merkle_value(b"AB").unwrap().unwrap();
 	assert_eq!(hash, expected);
+
+	// Key is not present in the tire.
+	// At the nibble level (4 bits), b"A" is represented by number 65 in binary: 0100 0001.
+	// The key 0000 01000 shares no common prefix in the trie.
+	let not_present = trie.get_closest_merkle_value(&[0b_0000_0100]).unwrap();
+	assert!(not_present.is_none());
+
+	// b"D" should exist since it shares a prefix with b"A" and it returns the branch node
+	// when the layout is `ExtensionLayout` or a nibble branch otherwise.
+	let d_key = trie.get_closest_merkle_value(&[0b_0100_0100]).unwrap().unwrap();
+	// The same is true for b"C".
+	let c_key = trie.get_closest_merkle_value(&[0b_0100_0011]).unwrap().unwrap();
+	// Check the same branch is returned.
+	assert_eq!(d_key, c_key);
 }
 
 test_layouts!(iterator_seek_with_recorder, iterator_seek_with_recorder_internal);

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -655,9 +655,9 @@ fn test_merkle_value_internal<T: TrieLayout>() {
 		(b"AA".to_vec(), vec![2; 64]),
 		(b"AAAA".to_vec(), vec![3; 64]),
 		(b"AAB".to_vec(), vec![4; 64]),
-		(b"AABBBB".to_vec(), vec![4; 64]),
-		(b"AB".to_vec(), vec![5; 4]),
-		(b"B".to_vec(), vec![6; 64]),
+		(b"AABBBB".to_vec(), vec![4; 1]),
+		(b"AB".to_vec(), vec![5; 1]),
+		(b"B".to_vec(), vec![6; 1]),
 	];
 	{
 		let mut t = TrieDBMutBuilder::<T>::new(&mut memdb, &mut root).build();

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -685,6 +685,8 @@ fn test_merkle_value_internal<T: TrieLayout>() {
 	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"BX").unwrap();
 	assert!(hash.is_none());
+	let hash = trie.get_closest_merkle_value(b"AC").unwrap();
+	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"BC").unwrap();
 	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"AAAAX").unwrap();
@@ -729,7 +731,9 @@ fn test_merkle_value_single_key_internal<T: TrieLayout>() {
 	let expected = trie.get_closest_merkle_value(b"AAA").unwrap().unwrap();
 	assert_eq!(hash, expected);
 
-	// Trie does not contain AAAA.
+	// Trie does not contain AAC or AAAA.
+	let hash = trie.get_closest_merkle_value(b"AAC").unwrap();
+	assert!(hash.is_none());
 	let hash = trie.get_closest_merkle_value(b"AAAA").unwrap();
 	assert!(hash.is_none());
 }


### PR DESCRIPTION
This PR adds support for fetching the merkle value directly from the trie-db.

- Adds `get_closest_merkle_value` on the `Trie` trait
- `TrieDb` iterates over the nibbles of the provided key
  - At each iteration DB is queried for the containing node
  - last value encountered on the path from the root to the key is returned
- During trie traversal, the internal recorder is updated with trie actions
  - This should make other trie queries to the key more efficient
- Test with `HashedValueNoExtThreshold<1>` as trie layout and value update at given key

We could build on this PR to have support for recorded Merkel Value in the cache.

Would love to get your thoughts on this @cheme @arkpar 🙏 
(For reference @tomaka to ensure we don't break anything wrt to compatibilities between smoldot and substrate)

Part of https://github.com/paritytech/substrate/issues/14550.

// @paritytech/subxt-team 

