### PR TITLE
chore: Release trie-db 0.28.0

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 hash-db = { path = "../../hash-db" , version = "0.16.0"}
 keccak-hasher = { path = "../keccak-hasher", version = "0.16.0" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.27.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.28.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.18.0" }
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 hashbrown = { version = "0.13.2", default-features = false, features = ["ahash"] }

--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.38.0] - 2023-09-12
+- chore: Release trie-db 0.28.0 [#200](https://github.com/paritytech/trie/pull/200)
+
 ## [0.37.0] - 2023-03-14
 - Update dependencies. [#188](https://github.com/paritytech/trie/pull/188) and [#187](https://github.com/paritytech/trie/pull/187)
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.16.0" }
 hash-db = { path = "../../hash-db" , version = "0.16.0"}
 memory-db = { path = "../../memory-db", version = "0.32.0" }
 trie-root = { path = "../../trie-root", version = "0.18.0" }
-trie-db = { path = "../../trie-db", version = "0.27.0" }
+trie-db = { path = "../../trie-db", version = "0.28.0" }
 criterion = "0.4.0"
 parity-scale-codec = "3.0.0"

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.28.0] - 2023-09-12
+- Make `trie_nodes_recorded_for_key` work for inline values [#194](https://github.com/paritytech/trie/pull/194)
+- trie-db: Fetch the closest merkle value [#199](https://github.com/paritytech/trie/pull/199)
+- fixing triedbmut lookup, added some testing in test. [#198](https://github.com/paritytech/trie/pull/198)
+
 ## [0.27.1] - 2023-03-17
 - Fix `TrieDBRawIterator::prefix_then_seek` [#190](https://github.com/paritytech/trie/pull/190)
 

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.27.1"
+version = "0.28.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -12,7 +12,7 @@ name = "bench"
 harness = false
 
 [dependencies]
-trie-db = { path = "..", version = "0.27.0"}
+trie-db = { path = "..", version = "0.28.0"}
 hash-db = { path = "../../hash-db", version = "0.16.0"}
 memory-db = { path = "../../memory-db", version = "0.32.0" }
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }

--- a/trie-eip1186/Cargo.toml
+++ b/trie-eip1186/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-db = { path = "../trie-db", default-features = false, version = "0.27.0"}
+trie-db = { path = "../trie-db", default-features = false, version = "0.28.0"}
 hash-db = { path = "../hash-db", default-features = false, version = "0.16.0"}
 
 [features]

--- a/trie-eip1186/test/Cargo.toml
+++ b/trie-eip1186/test/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 trie-eip1186 = { path = "..", version = "0.5.0"}
-trie-db = { path = "../../trie-db", version = "0.27.0"}
+trie-db = { path = "../../trie-db", version = "0.28.0"}
 hash-db = { path = "../../hash-db", version = "0.16.0"}
 reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }
 memory-db = { path = "../../memory-db", version = "0.32.0" }


### PR DESCRIPTION
This PR prepares the release of trie-db 0.28.0 to allow substrate https://github.com/paritytech/polkadot-sdk/pull/1153 to use the merkle value functionality.

The version has been bumped from 0.27.1 to 0.28.0 since the addition of `lookup_first_descendant` represents a breaking change for the `Trie` trait. 


## Changelog
## [0.28.0] - 2023-09-12
- Make `trie_nodes_recorded_for_key` work for inline values [#194](https://github.com/paritytech/trie/pull/194)
- trie-db: Fetch the closest merkle value [#199](https://github.com/paritytech/trie/pull/199)
- fixing triedbmut lookup, added some testing in test. [#198](https://github.com/paritytech/trie/pull/198)


@paritytech/subxt-team 