### PR TITLE
Fix recorder for `NonExisting` keys

### DIFF
--- a/trie-db/src/recorder.rs
+++ b/trie-db/src/recorder.rs
@@ -71,7 +71,7 @@ impl<L: TrieLayout> TrieRecorder<TrieHash<L>> for Recorder<L> {
 			},
 			TrieAccess::NonExisting { full_key } => {
 				// We handle the non existing value/hash like having recorded the value.
-				self.recorded_keys.entry(full_key.to_vec()).insert(RecordedForKey::None);
+				self.recorded_keys.entry(full_key.to_vec()).insert(RecordedForKey::Value);
 			},
 			TrieAccess::InlineValue { full_key } => {
 				self.recorded_keys.entry(full_key.to_vec()).insert(RecordedForKey::Value);

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -1167,7 +1167,7 @@ fn test_trie_nodes_recorded_internal<T: TrieLayout>() {
 			}
 
 			assert_eq!(
-				RecordedForKey::None,
+				RecordedForKey::Value,
 				recorder.trie_nodes_recorded_for_key(&NON_EXISTENT_KEY),
 			);
 		}


### PR DESCRIPTION
We handle `NonExisting` keys as if we have recorded the value. The reason behind this is that we have recorded all the trie nodes to proof that the key doesn't exist in the `trie`. So, next time we want to access the key we can use the `cache` (if present) and do not net to iterate over the trie nodes again.