### PR TITLE
Add DB generic type instead of dyn Trait to allow use the DB outside of the trie

### DIFF
--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -157,8 +157,8 @@ pub trait HashDBRef<H: Hasher, T> {
 	fn contains(&self, key: &H::Out, prefix: Prefix) -> bool;
 }
 
-impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a dyn HashDB<H, T> {
-	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+impl<'a, H: Hasher, V, T: HashDB<H, V>> HashDBRef<H, V> for &T {
+	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<V> {
 		HashDB::get(*self, key, prefix)
 	}
 	fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {
@@ -166,8 +166,8 @@ impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a dyn HashDB<H, T> {
 	}
 }
 
-impl<'a, H: Hasher, T> HashDBRef<H, T> for &'a mut dyn HashDB<H, T> {
-	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
+impl<'a, H: Hasher, V, T: HashDB<H, V>> HashDBRef<H, V> for &mut T {
+	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<V> {
 		HashDB::get(*self, key, prefix)
 	}
 	fn contains(&self, key: &H::Out, prefix: Prefix) -> bool {

--- a/test-support/trie-bench/src/lib.rs
+++ b/test-support/trie-bench/src/lib.rs
@@ -59,9 +59,12 @@ fn benchmark<L: TrieLayout, S: TrieStream>(
 		bench_list,
 		|b, d: &TrieInsertionList| {
 			b.iter(&mut || {
-				let mut memdb = MemoryDB::<_, HashKey<L::Hash>, _>::new(L::Codec::empty_node());
+				let mut memdb = MemoryDB::new(L::Codec::empty_node());
 				let mut root = <TrieHash<L>>::default();
-				let mut t = TrieDBMutBuilder::<L>::new(&mut memdb, &mut root).build();
+				let mut t = TrieDBMutBuilder::<L, MemoryDB<_, HashKey<L::Hash>, _>>::new(
+					&mut memdb, &mut root,
+				)
+				.build();
 				for i in d.0.iter() {
 					t.insert(&i.0, &i.1).unwrap();
 				}
@@ -72,16 +75,20 @@ fn benchmark<L: TrieLayout, S: TrieStream>(
 		BenchmarkId::new("Iter", bench_size),
 		bench_list,
 		|b, d: &TrieInsertionList| {
-			let mut memdb = MemoryDB::<_, HashKey<_>, _>::new(L::Codec::empty_node());
+			let mut memdb = MemoryDB::new(L::Codec::empty_node());
 			let mut root = <TrieHash<L>>::default();
 			{
-				let mut t = TrieDBMutBuilder::<L>::new(&mut memdb, &mut root).build();
+				let mut t = TrieDBMutBuilder::<L, MemoryDB<_, HashKey<L::Hash>, _>>::new(
+					&mut memdb, &mut root,
+				)
+				.build();
 				for i in d.0.iter() {
 					t.insert(&i.0, &i.1).unwrap();
 				}
 			}
 			b.iter(&mut || {
-				let t = TrieDBBuilder::<L>::new(&memdb, &root).build();
+				let t = TrieDBBuilder::<L, MemoryDB<_, HashKey<L::Hash>, _>>::new(&memdb, &root)
+					.build();
 				for n in t.iter().unwrap() {
 					black_box(n).unwrap();
 				}

--- a/test-support/trie-standardmap/src/lib.rs
+++ b/test-support/trie-standardmap/src/lib.rs
@@ -116,8 +116,9 @@ impl StandardMap {
 			let v = match self.value_mode {
 				ValueMode::Mirror => k.clone(),
 				ValueMode::Random => Self::random_value(seed),
-				ValueMode::Index =>
-					vec![index as u8, (index >> 8) as u8, (index >> 16) as u8, (index >> 24) as u8],
+				ValueMode::Index => {
+					vec![index as u8, (index >> 8) as u8, (index >> 16) as u8, (index >> 24) as u8]
+				},
 			};
 			d.push((k, v))
 		}

--- a/trie-db/src/fatdbmut.rs
+++ b/trie-db/src/fatdbmut.rs
@@ -22,48 +22,48 @@ use hash_db::{HashDB, Hasher, EMPTY_PREFIX};
 /// Additionaly it stores inserted hash-key mappings for later retrieval.
 ///
 /// Use it as a `Trie` or `TrieMut` trait object.
-pub struct FatDBMut<'db, L>
+pub struct FatDBMut<'db, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDB<L::Hash, DBValue>,
 {
-	raw: TrieDBMut<'db, L>,
+	raw: TrieDBMut<'db, L, DB>,
 }
 
-impl<'db, L> FatDBMut<'db, L>
+impl<'db, L, DB> FatDBMut<'db, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDB<L::Hash, DBValue>,
 {
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db mut dyn HashDB<L::Hash, DBValue>, root: &'db mut TrieHash<L>) -> Self {
+	pub fn new(db: &'db mut DB, root: &'db mut TrieHash<L>) -> Self {
 		FatDBMut { raw: TrieDBMutBuilder::new(db, root).build() }
 	}
 
 	/// Create a new trie with the backing database `db` and `root`.
 	///
 	/// Returns an error if root does not exist.
-	pub fn from_existing(
-		db: &'db mut dyn HashDB<L::Hash, DBValue>,
-		root: &'db mut TrieHash<L>,
-	) -> Self {
+	pub fn from_existing(db: &'db mut DB, root: &'db mut TrieHash<L>) -> Self {
 		FatDBMut { raw: TrieDBMutBuilder::from_existing(db, root).build() }
 	}
 
 	/// Get the backing database.
-	pub fn db(&self) -> &dyn HashDB<L::Hash, DBValue> {
+	pub fn db(&self) -> &DB {
 		self.raw.db()
 	}
 
 	/// Get the backing database.
-	pub fn db_mut(&mut self) -> &mut dyn HashDB<L::Hash, DBValue> {
+	pub fn db_mut(&mut self) -> &mut DB {
 		self.raw.db_mut()
 	}
 }
 
-impl<'db, L> TrieMut<L> for FatDBMut<'db, L>
+impl<'db, L, DB> TrieMut<L> for FatDBMut<'db, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDB<L::Hash, DBValue>,
 {
 	fn root(&mut self) -> &TrieHash<L> {
 		self.raw.root()

--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -544,7 +544,7 @@ where
 
 				Some(data.0)
 			},
-			Some(CachedValue::Existing { data, hash, .. }) =>
+			Some(CachedValue::Existing { data, hash, .. }) => {
 				if let Some(data) = data.upgrade() {
 					// inline is either when no limit defined or when content
 					// is less than the limit.
@@ -562,7 +562,8 @@ where
 					Some(data)
 				} else {
 					lookup_data(&mut self, cache)?
-				},
+				}
+			},
 			None => lookup_data(&mut self, cache)?,
 		};
 

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -325,7 +325,7 @@ where
 								*returned = true;
 								Some((None, child))
 							},
-						Self::Array(childs, index) =>
+						Self::Array(childs, index) => {
 							if *index >= childs.len() {
 								break None
 							} else {
@@ -335,7 +335,8 @@ where
 								if let Some(ref child) = childs[*index - 1] {
 									break Some((Some(*index as u8 - 1), child))
 								}
-							},
+							}
+						},
 					}
 				}
 			}

--- a/trie-db/src/proof/generate.rs
+++ b/trie-db/src/proof/generate.rs
@@ -250,7 +250,7 @@ where
 		// Perform the trie lookup for the next key, recording the sequence of nodes traversed.
 		let mut recorder = Recorder::<L>::new();
 		let expected_value = {
-			let trie = TrieDBBuilder::<L>::new(db, root).with_recorder(&mut recorder).build();
+			let trie = TrieDBBuilder::<L, D>::new(db, root).with_recorder(&mut recorder).build();
 			trie.get(key_bytes)?
 		};
 

--- a/trie-db/src/proof/verify.rs
+++ b/trie-db/src/proof/verify.rs
@@ -55,20 +55,24 @@ pub enum Error<HO, CE> {
 impl<HO: std::fmt::Debug, CE: std::error::Error> std::fmt::Display for Error<HO, CE> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
 		match self {
-			Error::DuplicateKey(key) =>
-				write!(f, "Duplicate key in input statement: key={:?}", key),
+			Error::DuplicateKey(key) => {
+				write!(f, "Duplicate key in input statement: key={:?}", key)
+			},
 			Error::ExtraneousNode => write!(f, "Extraneous node found in proof"),
-			Error::ExtraneousValue(key) =>
-				write!(f, "Extraneous value found in proof should have been omitted: key={:?}", key),
+			Error::ExtraneousValue(key) => {
+				write!(f, "Extraneous value found in proof should have been omitted: key={:?}", key)
+			},
 			Error::ExtraneousHashReference(hash) => write!(
 				f,
 				"Extraneous hash reference found in proof should have been omitted: hash={:?}",
 				hash
 			),
-			Error::InvalidChildReference(data) =>
-				write!(f, "Invalid child reference exceeds hash length: {:?}", data),
-			Error::ValueMismatch(key) =>
-				write!(f, "Expected value was not found in the trie: key={:?}", key),
+			Error::InvalidChildReference(data) => {
+				write!(f, "Invalid child reference exceeds hash length: {:?}", data)
+			},
+			Error::ValueMismatch(key) => {
+				write!(f, "Expected value was not found in the trie: key={:?}", key)
+			},
 			Error::IncompleteProof => write!(f, "Proof is incomplete -- expected more nodes"),
 			Error::RootMismatch(hash) => write!(f, "Computed incorrect root {:?} from proof", hash),
 			Error::DecodeError(err) => write!(f, "Unable to decode proof node: {}", err),
@@ -468,8 +472,9 @@ where
 					}
 					let computed_root = match child_ref {
 						ChildReference::Hash(hash) => hash,
-						ChildReference::Inline(_, _) =>
-							panic!("the bottom item on the stack has is_inline = false; qed"),
+						ChildReference::Inline(_, _) => {
+							panic!("the bottom item on the stack has is_inline = false; qed")
+						},
 					};
 					if computed_root != *root {
 						return Err(Error::RootMismatch(computed_root))

--- a/trie-db/src/sectriedb.rs
+++ b/trie-db/src/sectriedb.rs
@@ -21,39 +21,42 @@ use hash_db::{HashDBRef, Hasher};
 /// A `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
 ///
 /// Use it as a `Trie` trait object. You can use `raw()` to get the backing `TrieDB` object.
-pub struct SecTrieDB<'db, 'cache, L>
+pub struct SecTrieDB<'db, 'cache, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDBRef<L::Hash, DBValue>,
 {
-	raw: TrieDB<'db, 'cache, L>,
+	raw: TrieDB<'db, 'cache, L, DB>,
 }
 
-impl<'db, 'cache, L> SecTrieDB<'db, 'cache, L>
+impl<'db, 'cache, L, DB> SecTrieDB<'db, 'cache, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDBRef<L::Hash, DBValue>,
 {
 	/// Create a new trie with the backing database `db` and `root`.
 	///
 	/// Initialise to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db dyn HashDBRef<L::Hash, DBValue>, root: &'db TrieHash<L>) -> Self {
+	pub fn new(db: &'db DB, root: &'db TrieHash<L>) -> Self {
 		SecTrieDB { raw: TrieDBBuilder::new(db, root).build() }
 	}
 
 	/// Get a reference to the underlying raw `TrieDB` struct.
-	pub fn raw(&self) -> &TrieDB<'db, 'cache, L> {
+	pub fn raw(&self) -> &TrieDB<'db, 'cache, L, DB> {
 		&self.raw
 	}
 
 	/// Get a mutable reference to the underlying raw `TrieDB` struct.
-	pub fn raw_mut(&mut self) -> &mut TrieDB<'db, 'cache, L> {
+	pub fn raw_mut(&mut self) -> &mut TrieDB<'db, 'cache, L, DB> {
 		&mut self.raw
 	}
 }
 
-impl<'db, 'cache, L> Trie<L> for SecTrieDB<'db, 'cache, L>
+impl<'db, 'cache, L, DB> Trie<L> for SecTrieDB<'db, 'cache, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDBRef<L::Hash, DBValue>,
 {
 	fn root(&self) -> &TrieHash<L> {
 		self.raw.root()

--- a/trie-db/src/sectriedbmut.rs
+++ b/trie-db/src/sectriedbmut.rs
@@ -22,29 +22,28 @@ use hash_db::{HashDB, Hasher};
 ///
 /// Use it as a `Trie` or `TrieMut` trait object. You can use `raw()` to get the backing `TrieDBMut`
 /// object.
-pub struct SecTrieDBMut<'db, L>
+pub struct SecTrieDBMut<'db, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDB<L::Hash, DBValue>,
 {
-	raw: TrieDBMut<'db, L>,
+	raw: TrieDBMut<'db, L, DB>,
 }
 
-impl<'db, L> SecTrieDBMut<'db, L>
+impl<'db, L, DB> SecTrieDBMut<'db, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDB<L::Hash, DBValue>,
 {
 	/// Create a new trie with the backing database `db` and empty `root`
 	/// Initialize to the state entailed by the genesis block.
 	/// This guarantees the trie is built correctly.
-	pub fn new(db: &'db mut dyn HashDB<L::Hash, DBValue>, root: &'db mut TrieHash<L>) -> Self {
+	pub fn new(db: &'db mut DB, root: &'db mut TrieHash<L>) -> Self {
 		SecTrieDBMut { raw: TrieDBMutBuilder::new(db, root).build() }
 	}
 
 	/// Create a new trie with the backing database `db` and `root`.
-	pub fn from_existing(
-		db: &'db mut dyn HashDB<L::Hash, DBValue>,
-		root: &'db mut TrieHash<L>,
-	) -> Self {
+	pub fn from_existing(db: &'db mut DB, root: &'db mut TrieHash<L>) -> Self {
 		SecTrieDBMut { raw: TrieDBMutBuilder::from_existing(db, root).build() }
 	}
 
@@ -59,9 +58,10 @@ where
 	}
 }
 
-impl<'db, L> TrieMut<L> for SecTrieDBMut<'db, L>
+impl<'db, L, DB> TrieMut<L> for SecTrieDBMut<'db, L, DB>
 where
 	L: TrieLayout,
+	DB: HashDB<L::Hash, DBValue>,
 {
 	fn root(&mut self) -> &TrieHash<L> {
 		self.raw.root()

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -32,7 +32,7 @@ use crate::{
 	CError, ChildReference, DBValue, NibbleVec, NodeCodec, Result, TrieDB, TrieDBRawIterator,
 	TrieError, TrieHash, TrieLayout,
 };
-use hash_db::{HashDB, Prefix};
+use hash_db::{HashDB, HashDBRef, Prefix};
 
 const OMIT_VALUE_HASH: crate::node::Value<'static> = crate::node::Value::Inline(&[]);
 
@@ -187,8 +187,8 @@ impl<C: NodeCodec> EncoderStackEntry<C> {
 /// Detached value if included does write a reserved header,
 /// followed by node encoded with 0 length value and the value
 /// as a standalone vec.
-fn detached_value<L: TrieLayout>(
-	db: &TrieDB<L>,
+fn detached_value<L: TrieLayout, DB: HashDBRef<L::Hash, DBValue>>(
+	db: &TrieDB<L, DB>,
 	value: &ValuePlan,
 	node_data: &[u8],
 	node_prefix: Prefix,
@@ -216,9 +216,10 @@ fn detached_value<L: TrieLayout>(
 ///
 /// This function makes the assumption that all child references in an inline trie node are inline
 /// references.
-pub fn encode_compact<L>(db: &TrieDB<L>) -> Result<Vec<Vec<u8>>, TrieHash<L>, CError<L>>
+pub fn encode_compact<L, DB>(db: &TrieDB<L, DB>) -> Result<Vec<Vec<u8>>, TrieHash<L>, CError<L>>
 where
 	L: TrieLayout,
+	DB: HashDBRef<L::Hash, DBValue>,
 {
 	let mut output = Vec::new();
 

--- a/trie-db/test/src/iterator.rs
+++ b/trie-db/test/src/iterator.rs
@@ -68,8 +68,9 @@ fn iterator_works_internal<T: TrieLayout>() {
 			Some(Ok((prefix, Some(_), node))) => {
 				assert_eq!(prefix, nibble_vec(hex!(""), 0));
 				match node.node() {
-					Node::Extension(partial, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1)),
+					Node::Extension(partial, _) => {
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1))
+					},
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -102,8 +103,9 @@ fn iterator_works_internal<T: TrieLayout>() {
 			Some(Ok((prefix, None, node))) => {
 				assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
 				match node.node() {
-					Node::Leaf(partial, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1)),
+					Node::Leaf(partial, _) => {
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1))
+					},
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -129,8 +131,9 @@ fn iterator_works_internal<T: TrieLayout>() {
 			Some(Ok((prefix, Some(_), node))) => {
 				assert_eq!(prefix, nibble_vec(hex!(""), 0));
 				match node.node() {
-					Node::NibbledBranch(partial, _, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1)),
+					Node::NibbledBranch(partial, _, _) => {
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1))
+					},
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -144,8 +147,9 @@ fn iterator_works_internal<T: TrieLayout>() {
 				}
 				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
 				match node.node() {
-					Node::NibbledBranch(partial, _, _) =>
-						assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
+					Node::NibbledBranch(partial, _, _) => {
+						assert_eq!(partial, NibbleSlice::new(&hex!("")[..]))
+					},
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -159,8 +163,9 @@ fn iterator_works_internal<T: TrieLayout>() {
 				}
 				assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
 				match node.node() {
-					Node::Leaf(partial, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1)),
+					Node::Leaf(partial, _) => {
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1))
+					},
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -371,8 +376,9 @@ fn prefix_works_internal<T: TrieLayout>() {
 				}
 				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
 				match node.node() {
-					Node::NibbledBranch(partial, _, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0)),
+					Node::NibbledBranch(partial, _, _) => {
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0))
+					},
 					_ => panic!("unexpected node"),
 				}
 			},

--- a/trie-eip1186/src/eip1186.rs
+++ b/trie-eip1186/src/eip1186.rs
@@ -8,18 +8,19 @@ use trie_db::{
 };
 
 /// Generate an eip-1186 compatible proof for key-value pairs in a trie given a key.
-pub fn generate_proof<L>(
-	db: &dyn HashDBRef<L::Hash, DBValue>,
+pub fn generate_proof<L, DB>(
+	db: &DB,
 	root: &TrieHash<L>,
 	key: &[u8],
 ) -> TrieResult<(Vec<Vec<u8>>, Option<Vec<u8>>), TrieHash<L>, CError<L>>
 where
 	L: TrieLayout,
+	DB: HashDBRef<L::Hash, DBValue>,
 {
 	let mut recorder = Recorder::<L>::new();
 
 	let item = {
-		let trie = TrieDBBuilder::<L>::new(db, root).with_recorder(&mut recorder).build();
+		let trie = TrieDBBuilder::<L, DB>::new(db, root).with_recorder(&mut recorder).build();
 		trie.get(key)?
 	};
 


### PR DESCRIPTION
Hello,

This crate is awesome and provides a lot of flexibility and cool features. Thanks for this very nice work.

When we used it, we had a problem with the way you hold the DB. In the `TrieDBMut` for example, you hold a mutable reference over the database that prevents us to have another reference in our code to do custom things such as modifying the DB content (in our case we save all changes that you make in the DB to allow user to rollback or rollforward his trie).

We can have a reference (mutable or not) to our DB using your method `db()` or `db_mut()` but it only give us the reference over something that implements `HashDB` that allows us to use only the methods defined in `HashDB` trait and not our custom ones.

This PR propose to fix this problem by replacing the `dyn HashDB` by providing a concrete generic type that needs to implement `HashDB` trait. This allow us to change `db()` and `db_mut()` to return our concrete type and be able to have fully access to the methods we created.

I would love to have your feedback on this. If it's something you already encoured and you have other solutions, I will be very happy to heard them.

Thanks again for your work