### PR TITLE
Implements `DoubleEndedIterator` for trie iterators

### DIFF
--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use hash_db::{HashDBRef, Hasher};
 
-use crate::{rstd::boxed::Box, MerkleValue, TrieDBBuilder};
+use crate::{rstd::boxed::Box, triedb::TrieDBDoubleEndedIterator, MerkleValue, TrieDBBuilder};
 
 /// A `Trie` implementation which hashes keys and uses a generic `HashDB` backing database.
 /// Additionaly it stores inserted hash-key mappings for later retrieval.
@@ -109,6 +109,22 @@ where
 	trie: &'db TrieDB<'db, 'cache, L>,
 }
 
+/// Double ended iterator over inserted pairs of key values.
+pub struct FatDBDoubleEndedIterator<'db, 'cache, L>
+where
+	L: TrieLayout,
+{
+	trie_iterator: TrieDBDoubleEndedIterator<'db, 'cache, L>,
+	trie: &'db TrieDB<'db, 'cache, L>,
+}
+
+impl<'a, 'cache, L: TrieLayout> FatDBDoubleEndedIterator<'a, 'cache, L> {
+	/// Create a new double ended iterator.
+	pub fn new(db: &'a TrieDB<'a, 'cache, L>) -> Result<Self, TrieHash<L>, CError<L>> {
+		Ok(Self { trie_iterator: TrieDBDoubleEndedIterator::new(db)?, trie: db })
+	}
+}
+
 impl<'db, 'cache, L> FatDBIterator<'db, 'cache, L>
 where
 	L: TrieLayout,
@@ -148,7 +164,36 @@ where
 	}
 }
 
-impl<'db, 'cache, L> DoubleEndedIterator for FatDBIterator<'db, 'cache, L>
+impl<'db, 'cache, L> TrieIterator<L> for FatDBDoubleEndedIterator<'db, 'cache, L>
+where
+	L: TrieLayout,
+{
+	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
+		let hashed_key = L::Hash::hash(key);
+		self.trie_iterator.seek(hashed_key.as_ref())
+	}
+}
+
+impl<'db, 'cache, L> Iterator for FatDBDoubleEndedIterator<'db, 'cache, L>
+where
+	L: TrieLayout,
+{
+	type Item = TrieItem<TrieHash<L>, CError<L>>;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.trie_iterator.next().map(|res| {
+			res.map(|(hash, value)| {
+				let aux_hash = L::Hash::hash(&hash);
+				(
+					self.trie.db().get(&aux_hash, Default::default()).expect("Missing fatdb hash"),
+					value,
+				)
+			})
+		})
+	}
+}
+
+impl<'db, 'cache, L> DoubleEndedIterator for FatDBDoubleEndedIterator<'db, 'cache, L>
 where
 	L: TrieLayout,
 {

--- a/trie-db/src/fatdb.rs
+++ b/trie-db/src/fatdb.rs
@@ -254,17 +254,3 @@ where
 		})
 	}
 }
-
-impl<'db, 'cache, L> DoubleEndedIterator for FatDBKeyIterator<'db, 'cache, L>
-where
-	L: TrieLayout,
-{
-	fn next_back(&mut self) -> Option<Self::Item> {
-		self.trie_iterator.next_back().map(|res| {
-			res.map(|hash| {
-				let aux_hash = L::Hash::hash(&hash);
-				self.trie.db().get(&aux_hash, Default::default()).expect("Missing fatdb hash")
-			})
-		})
-	}
-}

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -704,7 +704,8 @@ impl<L: TrieLayout> TrieDoubleEndedIterator<L> for TrieDBNodeDoubleEndedIterator
 
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBNodeDoubleEndedIterator<'a, 'cache, L> {
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key).map(|_| ())?;
+		self.back_raw_iter.seek(self.db, key).map(|_| ())
 	}
 }
 

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -599,15 +599,6 @@ impl<'a, 'cache, L: TrieLayout> TrieDBNodeIterator<'a, 'cache, L> {
 		self.raw_iter
 	}
 
-	/// Convert the iterator to a double ended iterator.
-	pub fn into_double_ended_iter(self) -> TrieDBNodeDoubleEndedIterator<'a, 'cache, L> {
-		TrieDBNodeDoubleEndedIterator {
-			db: self.db,
-			raw_iter: self.raw_iter,
-			back_raw_iter: TrieDBRawIterator::new(self.db).unwrap(),
-		}
-	}
-
 	/// Fetch value by hash at a current node height
 	pub fn fetch_value(
 		&self,

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -64,7 +64,7 @@ impl<H: Hasher> Crumb<H> {
 			(Status::Entering, NodePlan::Branch { .. }) |
 			(Status::Entering, NodePlan::NibbledBranch { .. }) => Status::At,
 			(Status::At, NodePlan::Branch { .. }) |
-			(Status::At, NodePlan::NibbledBranch { .. }) => Status::AtChild(15),
+			(Status::At, NodePlan::NibbledBranch { .. }) => Status::AtChild(nibble_ops::NIBBLE_LENGTH - 1),
 			(Status::AtChild(x), NodePlan::Branch { .. }) |
 			(Status::AtChild(x), NodePlan::NibbledBranch { .. })
 				if x > 0 =>

--- a/trie-db/src/iterator.rs
+++ b/trie-db/src/iterator.rs
@@ -67,7 +67,7 @@ impl<H: Hasher> Crumb<H> {
 			(Status::At, NodePlan::NibbledBranch { .. }) => Status::AtChild(15),
 			(Status::AtChild(x), NodePlan::Branch { .. }) |
 			(Status::AtChild(x), NodePlan::NibbledBranch { .. })
-				if x <= (nibble_ops::NIBBLE_LENGTH - 1) =>
+				if x > 0 =>
 				Status::AtChild(x - 1),
 			_ => Status::Exiting,
 		}
@@ -553,9 +553,6 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 						self.key_nibbles.pop();
 						self.key_nibbles.push(i as u8);
 
-						println!("prefix: {:?}", self.key_nibbles);
-						println!("child: {:?}", child);
-
 						match db.get_raw_or_lookup(
 							crumb.hash.unwrap_or_default(),
 							child.build(node_data),
@@ -723,15 +720,10 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 				Err(err) => return Some(Err(err)),
 			};
 
-			println!("prefix received: {:?}", prefix);
-			println!("node received: {:?}", node);
-
 			let mut prefix = prefix.clone();
 			match node.node() {
 				Node::Leaf(partial, _) => {
 					prefix.append_partial(partial.right());
-
-					println!("prefix after append: {:?}", prefix);
 				},
 				Node::Branch(_, value) =>
 					if value.is_none() {
@@ -750,11 +742,8 @@ impl<L: TrieLayout> TrieDBRawIterator<L> {
 			let key = key_slice.to_vec();
 
 			if let Some(extra_nibble) = maybe_extra_nibble {
-				println!("extra nibble: {:?}", extra_nibble);
 				return Some(Err(Box::new(TrieError::ValueAtIncompleteKey(key, extra_nibble))))
 			}
-
-			println!("key: {:?}", key);
 
 			return Some(Ok(key))
 		}

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -353,7 +353,7 @@ pub trait TrieMut<L: TrieLayout> {
 }
 
 /// A trie iterator that also supports random access (`seek()`).
-pub trait TrieIterator<L: TrieLayout>: Iterator {
+pub trait TrieIterator<L: TrieLayout>: Iterator + DoubleEndedIterator {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>>;
 }

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -352,7 +352,7 @@ pub trait TrieMut<L: TrieLayout> {
 	fn remove(&mut self, key: &[u8]) -> Result<Option<Value<L>>, TrieHash<L>, CError<L>>;
 }
 
-/// A trie iterator that also supports random access (`seek()`).
+/// A double ended trie iterator that also supports random access (`seek()`).
 pub trait TrieIterator<L: TrieLayout>: Iterator + DoubleEndedIterator {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>>;

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -25,7 +25,7 @@ mod rstd {
 		collections::{BTreeMap, VecDeque},
 		convert,
 		error::Error,
-		fmt, hash, iter, marker, mem, ops, rc, result, sync, vec,
+		fmt, hash, iter, marker, mem, ops, result, sync, vec,
 	};
 }
 
@@ -46,6 +46,7 @@ use self::rstd::{fmt, Error};
 
 use self::rstd::{boxed::Box, vec::Vec};
 use hash_db::MaybeDebug;
+pub use iterator::TrieDBNodeDoubleEndedIterator;
 use node::NodeOwned;
 
 pub mod node;
@@ -352,11 +353,14 @@ pub trait TrieMut<L: TrieLayout> {
 	fn remove(&mut self, key: &[u8]) -> Result<Option<Value<L>>, TrieHash<L>, CError<L>>;
 }
 
-/// A double ended trie iterator that also supports random access (`seek()`).
-pub trait TrieIterator<L: TrieLayout>: Iterator + DoubleEndedIterator {
+/// A trie iterator that also supports random access (`seek()`).
+pub trait TrieIterator<L: TrieLayout>: Iterator {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>>;
 }
+
+/// Extending the `TrieIterator` trait with `DoubleEndedIterator` trait.
+pub trait TrieDoubleEndedIterator<L: TrieLayout>: TrieIterator<L> + DoubleEndedIterator {}
 
 /// Trie types
 #[derive(PartialEq, Clone)]

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -582,7 +582,7 @@ impl NodePlan {
 /// An `OwnedNode` is an owned type from which a `Node` can be constructed which borrows data from
 /// the `OwnedNode`. This is useful for trie iterators.
 #[cfg_attr(feature = "std", derive(Debug))]
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct OwnedNode<D: Borrow<[u8]>> {
 	data: D,
 	plan: NodePlan,

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -582,7 +582,7 @@ impl NodePlan {
 /// An `OwnedNode` is an owned type from which a `Node` can be constructed which borrows data from
 /// the `OwnedNode`. This is useful for trie iterators.
 #[cfg_attr(feature = "std", derive(Debug))]
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq)]
 pub struct OwnedNode<D: Borrow<[u8]>> {
 	data: D,
 	plan: NodePlan,

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -236,7 +236,7 @@ where
 	// iteration of the loop below, the stack always has at least one entry and the bottom (front)
 	// of the stack is the root node, which is not inline. Furthermore, the iterator is not empty,
 	// so at least one iteration always occurs.
-	while let Some(item) = iter.next_raw_item(db) {
+	while let Some(item) = iter.next_raw_item(db, true) {
 		match item {
 			Ok((prefix, node_hash, node)) => {
 				// Skip inline nodes, as they cannot contain hash references to other nodes by

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -539,7 +539,7 @@ impl<'a, 'cache, L: TrieLayout> TrieDBIterator<'a, 'cache, L> {
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBIterator<'a, 'cache, L> {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key, true).map(|_| ())
 	}
 }
 
@@ -553,8 +553,8 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBIterator<'a, 'cache, L> {
 
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBDoubleEndedIterator<'a, 'cache, L> {
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek(self.db, key).map(|_| ())?;
-		self.back_raw_iter.seek(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key, true).map(|_| ())?;
+		self.back_raw_iter.seek(self.db, key, false).map(|_| ())
 	}
 }
 
@@ -611,7 +611,7 @@ impl<'a, 'cache, L: TrieLayout> TrieDBKeyIterator<'a, 'cache, L> {
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBKeyIterator<'a, 'cache, L> {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key, true).map(|_| ())
 	}
 }
 
@@ -626,8 +626,8 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBKeyIterator<'a, 'cache, L> {
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBKeyDoubleEndedIterator<'a, 'cache, L> {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek(self.db, key).map(|_| ())?;
-		self.back_raw_iter.seek(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key, true).map(|_| ())?;
+		self.back_raw_iter.seek(self.db, key, false).map(|_| ())
 	}
 }
 

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -547,7 +547,7 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBIterator<'a, 'cache, L> {
 	type Item = TrieItem<TrieHash<L>, CError<L>>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		self.raw_iter.next_item(self.db, true)
+		self.raw_iter.next_item(self.db)
 	}
 }
 
@@ -561,13 +561,13 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBDoubleEndedIterator<'a, 'cach
 	type Item = TrieItem<TrieHash<L>, CError<L>>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		self.raw_iter.next_item(self.db, true)
+		self.raw_iter.next_item(self.db)
 	}
 }
 
 impl<'a, 'cache, L: TrieLayout> DoubleEndedIterator for TrieDBDoubleEndedIterator<'a, 'cache, L> {
 	fn next_back(&mut self) -> Option<Self::Item> {
-		self.back_raw_iter.next_item(self.db, false)
+		self.back_raw_iter.prev_item(self.db)
 	}
 }
 
@@ -618,13 +618,7 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBKeyIterator<'a, 'cache, L> {
 	type Item = TrieKeyItem<TrieHash<L>, CError<L>>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		self.raw_iter.next_key(self.db, true)
-	}
-}
-
-impl<'a, 'cache, L: TrieLayout> DoubleEndedIterator for TrieDBKeyIterator<'a, 'cache, L> {
-	fn next_back(&mut self) -> Option<Self::Item> {
-		self.raw_iter.next_key(self.db, false)
+		self.raw_iter.next_key(self.db)
 	}
 }
 
@@ -639,7 +633,7 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBKeyDoubleEndedIterator<'a, 'c
 	type Item = TrieKeyItem<TrieHash<L>, CError<L>>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		self.raw_iter.next_key(self.db, true)
+		self.raw_iter.next_key(self.db)
 	}
 }
 
@@ -647,6 +641,6 @@ impl<'a, 'cache, L: TrieLayout> DoubleEndedIterator
 	for TrieDBKeyDoubleEndedIterator<'a, 'cache, L>
 {
 	fn next_back(&mut self) -> Option<Self::Item> {
-		self.back_raw_iter.next_key(self.db, false)
+		self.back_raw_iter.prev_key(self.db)
 	}
 }

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -525,10 +525,22 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBIterator<'a, 'cache, L> {
 	}
 }
 
+impl<'a, 'cache, L: TrieLayout> DoubleEndedIterator for TrieDBIterator<'a, 'cache, L> {
+	fn next_back(&mut self) -> Option<Self::Item> {
+		self.raw_iter.next_back_item(self.db)
+	}
+}
+
 impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBKeyIterator<'a, 'cache, L> {
 	type Item = TrieKeyItem<TrieHash<L>, CError<L>>;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		self.raw_iter.next_key(self.db)
+	}
+}
+
+impl<'a, 'cache, L: TrieLayout> DoubleEndedIterator for TrieDBKeyIterator<'a, 'cache, L> {
+	fn next_back(&mut self) -> Option<Self::Item> {
+		self.raw_iter.next_back_key(self.db)
 	}
 }

--- a/trie-db/src/triedb.rs
+++ b/trie-db/src/triedb.rs
@@ -553,7 +553,8 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBIterator<'a, 'cache, L> {
 
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBDoubleEndedIterator<'a, 'cache, L> {
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key).map(|_| ())?;
+		self.back_raw_iter.seek(self.db, key).map(|_| ())
 	}
 }
 
@@ -625,7 +626,8 @@ impl<'a, 'cache, L: TrieLayout> Iterator for TrieDBKeyIterator<'a, 'cache, L> {
 impl<'a, 'cache, L: TrieLayout> TrieIterator<L> for TrieDBKeyDoubleEndedIterator<'a, 'cache, L> {
 	/// Position the iterator on the first element with key >= `key`
 	fn seek(&mut self, key: &[u8]) -> Result<(), TrieHash<L>, CError<L>> {
-		self.raw_iter.seek(self.db, key).map(|_| ())
+		self.raw_iter.seek(self.db, key).map(|_| ())?;
+		self.back_raw_iter.seek(self.db, key).map(|_| ())
 	}
 }
 

--- a/trie-db/test/src/double_ended_iterator.rs
+++ b/trie-db/test/src/double_ended_iterator.rs
@@ -335,3 +335,27 @@ fn prefix_works_internal<T: TrieLayout>() {
 	iter.prefix(&hex!("10").to_vec()[..]).unwrap();
 	assert!(iter.next_back().is_none());
 }
+
+test_layouts!(prefix_over_empty_works, prefix_over_empty_works_internal);
+fn prefix_over_empty_works_internal<T: TrieLayout>() {
+	let (memdb, root) = build_trie_db::<T>(&[]);
+	let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
+	let mut iter = TrieDBNodeDoubleEndedIterator::new(&trie).unwrap();
+	iter.prefix(&hex!("")[..]).unwrap();
+	match iter.next_back() {
+		Some(Ok((prefix, Some(_), node))) => {
+			assert_eq!(prefix, nibble_vec(hex!(""), 0));
+			match node.node() {
+				Node::Empty => {},
+				_ => panic!("unexpected node"),
+			}
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	assert!(iter.next_back().is_none());
+
+	let mut iter = TrieDBNodeDoubleEndedIterator::new(&trie).unwrap();
+	iter.prefix(&hex!("00")[..]).unwrap();
+	assert!(iter.next_back().is_none());
+}

--- a/trie-db/test/src/double_ended_iterator.rs
+++ b/trie-db/test/src/double_ended_iterator.rs
@@ -240,6 +240,7 @@ fn prefix_works_internal<T: TrieLayout>() {
 	let pairs = vec![
 		(hex!("01").to_vec(), b"aaaa".to_vec()),
 		(hex!("0123").to_vec(), b"bbbb".to_vec()),
+		(hex!("0122").to_vec(), b"cccc".to_vec()),
 		(hex!("02").to_vec(), vec![1; 32]),
 	];
 
@@ -284,8 +285,40 @@ fn prefix_works_internal<T: TrieLayout>() {
 			}
 			assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
 			match node.node() {
+				Node::NibbledBranch(partial, _, _) =>
+					assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
+				Node::Branch(_, _) => {},
+				_ => panic!("unexpected node"),
+			}
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	match iter.next_back() {
+		Some(Ok((prefix, hash, node))) => {
+			if !can_expand {
+				debug_assert!(hash.is_none());
+			}
+			assert_eq!(prefix, nibble_vec(hex!("0123"), 4));
+			match node.node() {
 				Node::Leaf(partial, _) => {
-					assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1))
+					assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0))
+				},
+				_ => panic!("unexpected node"),
+			}
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	match iter.next_back() {
+		Some(Ok((prefix, hash, node))) => {
+			if !can_expand {
+				debug_assert!(hash.is_none());
+			}
+			assert_eq!(prefix, nibble_vec(hex!("0122"), 4));
+			match node.node() {
+				Node::Leaf(partial, _) => {
+					assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0))
 				},
 				_ => panic!("unexpected node"),
 			}

--- a/trie-db/test/src/double_ended_iterator.rs
+++ b/trie-db/test/src/double_ended_iterator.rs
@@ -234,8 +234,8 @@ fn seek_back_works_internal<T: TrieLayout>() {
 	assert!(iter.next_back().is_none());
 }
 
-test_layouts!(prefix_works, prefix_works_internal);
-fn prefix_works_internal<T: TrieLayout>() {
+test_layouts!(prefix_back_works, prefix_back_works_internal);
+fn prefix_back_works_internal<T: TrieLayout>() {
 	let can_expand = T::MAX_INLINE_VALUE.unwrap_or(T::Hash::LENGTH as u32) < T::Hash::LENGTH as u32;
 	let pairs = vec![
 		(hex!("01").to_vec(), b"aaaa".to_vec()),

--- a/trie-db/test/src/double_ended_iterator.rs
+++ b/trie-db/test/src/double_ended_iterator.rs
@@ -37,10 +37,32 @@ fn node_double_ended_iterator<T: TrieLayout>() {
 	if T::USE_EXTENSION {
 		match iter.next_back() {
 			Some(Ok((prefix, Some(_), node))) => {
-				assert_eq!(prefix, nibble_vec(hex!(""), 0));
+				assert_eq!(prefix, nibble_vec(hex!("02"), 2));
 				match node.node() {
-					Node::Extension(partial, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1)),
+					Node::Leaf(partial, _) => assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, None, node))) => {
+				assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
+				match node.node() {
+					Node::Leaf(partial, _) =>
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1)),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, None, node))) => {
+				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
+				match node.node() {
+					Node::Branch(_, _) => {},
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -57,34 +79,13 @@ fn node_double_ended_iterator<T: TrieLayout>() {
 			},
 			_ => panic!("unexpected item"),
 		}
+
 		match iter.next_back() {
 			Some(Ok((prefix, Some(_), node))) => {
-				assert_eq!(prefix, nibble_vec(hex!("02"), 2));
+				assert_eq!(prefix, nibble_vec(hex!(""), 0));
 				match node.node() {
-					Node::Leaf(partial, _) => assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
-					_ => panic!("unexpected node"),
-				}
-			},
-			_ => panic!("unexpected item"),
-		}
-
-		match iter.next_back() {
-			Some(Ok((prefix, None, node))) => {
-				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
-				match node.node() {
-					Node::Branch(_, _) => {},
-					_ => panic!("unexpected node"),
-				}
-			},
-			_ => panic!("unexpected item"),
-		}
-
-		match iter.next_back() {
-			Some(Ok((prefix, None, node))) => {
-				assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
-				match node.node() {
-					Node::Leaf(partial, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1)),
+					Node::Extension(partial, _) =>
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1)),
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -98,37 +99,9 @@ fn node_double_ended_iterator<T: TrieLayout>() {
 
 		match iter.next_back() {
 			Some(Ok((prefix, Some(_), node))) => {
-				assert_eq!(prefix, nibble_vec(hex!(""), 0));
-				match node.node() {
-					Node::NibbledBranch(partial, _, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1)),
-					_ => panic!("unexpected node"),
-				}
-			},
-			_ => panic!("unexpected item"),
-		}
-
-		// Start from the last element and move backwards
-		match iter.next_back() {
-			Some(Ok((prefix, Some(_), node))) => {
 				assert_eq!(prefix, nibble_vec(hex!("02"), 2));
 				match node.node() {
 					Node::Leaf(partial, _) => assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
-					_ => panic!("unexpected node"),
-				}
-			},
-			_ => panic!("unexpected item"),
-		}
-
-		match iter.next_back() {
-			Some(Ok((prefix, hash, node))) => {
-				if !can_expand {
-					assert!(hash.is_none());
-				}
-				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
-				match node.node() {
-					Node::NibbledBranch(partial, _, _) =>
-						assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -144,6 +117,33 @@ fn node_double_ended_iterator<T: TrieLayout>() {
 				match node.node() {
 					Node::Leaf(partial, _) =>
 						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1)),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, hash, node))) => {
+				if !can_expand {
+					assert!(hash.is_none());
+				}
+				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
+				match node.node() {
+					Node::NibbledBranch(partial, _, _) =>
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0)),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, Some(_), node))) => {
+				assert_eq!(prefix, nibble_vec(hex!(""), 0));
+				match node.node() {
+					Node::NibbledBranch(partial, _, _) =>
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1)),
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -172,8 +172,19 @@ fn seek_back_over_empty_works_internal<T: TrieLayout>() {
 		_ => panic!("unexpected item"),
 	}
 
-	<dyn TrieDoubleEndedIterator<T, Item = _>>::seek(&mut iter, &hex!("00")[..]).unwrap();
 	assert!(iter.next_back().is_none());
+
+	<dyn TrieDoubleEndedIterator<T, Item = _>>::seek(&mut iter, &hex!("00")[..]).unwrap();
+	match iter.next_back() {
+		Some(Ok((prefix, _, node))) => {
+			assert_eq!(prefix, nibble_vec(hex!(""), 0));
+			match node.node() {
+				Node::Empty => {},
+				_ => panic!("unexpected node"),
+			}
+		},
+		_ => panic!("unexpected item"),
+	}
 }
 
 test_layouts!(seek_back_works, seek_back_works_internal);
@@ -210,6 +221,27 @@ fn seek_back_works_internal<T: TrieLayout>() {
 	<dyn TrieDoubleEndedIterator<T, Item = _>>::seek(&mut iter, &hex!("01")[..]).unwrap();
 	match iter.next_back() {
 		Some(Ok((prefix, _, _))) => {
+			assert_eq!(prefix, nibble_vec(hex!("0123"), 4));
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	match iter.next_back() {
+		Some(Ok((prefix, _, _))) => {
+			assert_eq!(prefix, nibble_vec(hex!("0122"), 4));
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	match iter.next_back() {
+		Some(Ok((prefix, _, _))) => {
+			assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	match iter.next_back() {
+		Some(Ok((prefix, _, _))) => {
 			assert_eq!(prefix, nibble_vec(hex!("01"), 2));
 		},
 		_ => panic!("unexpected item"),
@@ -231,7 +263,19 @@ fn seek_back_works_internal<T: TrieLayout>() {
 	}
 
 	<dyn TrieDoubleEndedIterator<T, Item = _>>::seek(&mut iter, &hex!("0120")[..]).unwrap();
-	assert!(iter.next_back().is_none());
+	match iter.next_back() {
+		Some(Ok((prefix, _, _))) => {
+			assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	match iter.next_back() {
+		Some(Ok((prefix, _, _))) => {
+			assert_eq!(prefix, nibble_vec(hex!("01"), 2));
+		},
+		_ => panic!("unexpected item"),
+	}
 }
 
 test_layouts!(prefix_back_works, prefix_back_works_internal);
@@ -253,9 +297,11 @@ fn prefix_back_works_internal<T: TrieLayout>() {
 	if T::USE_EXTENSION {
 		match iter.next_back() {
 			Some(Ok((prefix, None, node))) => {
-				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
+				assert_eq!(prefix, nibble_vec(hex!("0123"), 4));
 				match node.node() {
-					Node::Branch(_, _) => {},
+					Node::Leaf(partial, _) => {
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0))
+					},
 					_ => panic!("unexpected node"),
 				}
 			},
@@ -267,47 +313,16 @@ fn prefix_back_works_internal<T: TrieLayout>() {
 				if !can_expand {
 					debug_assert!(hash.is_none());
 				}
-				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
+				assert_eq!(prefix, nibble_vec(hex!("0123"), 4));
 				match node.node() {
-					Node::NibbledBranch(partial, _, _) =>
-						assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0)),
+					Node::Leaf(partial, _) => {
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0))
+					},
 					_ => panic!("unexpected node"),
 				}
 			},
 			_ => panic!("unexpected item"),
 		}
-	}
-
-	match iter.next_back() {
-		Some(Ok((prefix, hash, node))) => {
-			if !can_expand {
-				debug_assert!(hash.is_none());
-			}
-			assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
-			match node.node() {
-				Node::NibbledBranch(partial, _, _) =>
-					assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
-				Node::Branch(_, _) => {},
-				_ => panic!("unexpected node"),
-			}
-		},
-		_ => panic!("unexpected item"),
-	}
-
-	match iter.next_back() {
-		Some(Ok((prefix, hash, node))) => {
-			if !can_expand {
-				debug_assert!(hash.is_none());
-			}
-			assert_eq!(prefix, nibble_vec(hex!("0123"), 4));
-			match node.node() {
-				Node::Leaf(partial, _) => {
-					assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0))
-				},
-				_ => panic!("unexpected node"),
-			}
-		},
-		_ => panic!("unexpected item"),
 	}
 
 	match iter.next_back() {
@@ -320,6 +335,38 @@ fn prefix_back_works_internal<T: TrieLayout>() {
 				Node::Leaf(partial, _) => {
 					assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0))
 				},
+				_ => panic!("unexpected node"),
+			}
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	match iter.next_back() {
+		Some(Ok((prefix, hash, node))) => {
+			if !can_expand {
+				debug_assert!(hash.is_none());
+			}
+			assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
+			match node.node() {
+				Node::NibbledBranch(partial, _, _) =>
+					assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0)),
+				Node::Branch(_, _) => {},
+				_ => panic!("unexpected node"),
+			}
+		},
+		_ => panic!("unexpected item"),
+	}
+
+	match iter.next_back() {
+		Some(Ok((prefix, hash, node))) => {
+			if !can_expand {
+				debug_assert!(hash.is_none());
+			}
+			assert_eq!(prefix, nibble_vec(hex!("01"), 2));
+			match node.node() {
+				Node::NibbledBranch(partial, _, _) =>
+					assert_eq!(partial, NibbleSlice::new_offset(&hex!("")[..], 0)),
+				Node::Branch(_, _) => {},
 				_ => panic!("unexpected node"),
 			}
 		},

--- a/trie-db/test/src/double_ended_iterator.rs
+++ b/trie-db/test/src/double_ended_iterator.rs
@@ -1,0 +1,152 @@
+// Copyright 2017, 2020 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use hash_db::Hasher;
+use hex_literal::hex;
+use reference_trie::test_layouts;
+use trie_db::{node::Node, NibbleSlice, TrieDBBuilder, TrieDBNodeDoubleEndedIterator, TrieLayout};
+
+use crate::iterator::{build_trie_db, nibble_vec};
+
+test_layouts!(node_double_ended_iterator_works, node_double_ended_iterator);
+fn node_double_ended_iterator<T: TrieLayout>() {
+	let pairs = vec![
+		(hex!("01").to_vec(), b"aaaa".to_vec()),
+		(hex!("0123").to_vec(), b"bbbb".to_vec()),
+		(hex!("02").to_vec(), vec![1; 32]),
+	];
+
+	let (memdb, root) = build_trie_db::<T>(&pairs);
+	let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
+	let mut iter = TrieDBNodeDoubleEndedIterator::new(&trie).unwrap();
+
+	if T::USE_EXTENSION {
+		match iter.next_back() {
+			Some(Ok((prefix, Some(_), node))) => {
+				assert_eq!(prefix, nibble_vec(hex!(""), 0));
+				match node.node() {
+					Node::Extension(partial, _) =>
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1)),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, Some(_), node))) => {
+				assert_eq!(prefix, nibble_vec(hex!("00"), 1));
+				match node.node() {
+					Node::Branch(_, _) => {},
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+		match iter.next_back() {
+			Some(Ok((prefix, Some(_), node))) => {
+				assert_eq!(prefix, nibble_vec(hex!("02"), 2));
+				match node.node() {
+					Node::Leaf(partial, _) => assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, None, node))) => {
+				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
+				match node.node() {
+					Node::Branch(_, _) => {},
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, None, node))) => {
+				assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
+				match node.node() {
+					Node::Leaf(partial, _) =>
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1)),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		assert!(iter.next_back().is_none());
+	} else {
+		let can_expand =
+			T::MAX_INLINE_VALUE.unwrap_or(T::Hash::LENGTH as u32) < T::Hash::LENGTH as u32;
+
+		match iter.next_back() {
+			Some(Ok((prefix, Some(_), node))) => {
+				assert_eq!(prefix, nibble_vec(hex!(""), 0));
+				match node.node() {
+					Node::NibbledBranch(partial, _, _) =>
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("00")[..], 1)),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		// Start from the last element and move backwards
+		match iter.next_back() {
+			Some(Ok((prefix, Some(_), node))) => {
+				assert_eq!(prefix, nibble_vec(hex!("02"), 2));
+				match node.node() {
+					Node::Leaf(partial, _) => assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, hash, node))) => {
+				if !can_expand {
+					assert!(hash.is_none());
+				}
+				assert_eq!(prefix, nibble_vec(hex!("01"), 2));
+				match node.node() {
+					Node::NibbledBranch(partial, _, _) =>
+						assert_eq!(partial, NibbleSlice::new(&hex!("")[..])),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		match iter.next_back() {
+			Some(Ok((prefix, hash, node))) => {
+				if !can_expand {
+					assert!(hash.is_none());
+				}
+				assert_eq!(prefix, nibble_vec(hex!("0120"), 3));
+				match node.node() {
+					Node::Leaf(partial, _) =>
+						assert_eq!(partial, NibbleSlice::new_offset(&hex!("03")[..], 1)),
+					_ => panic!("unexpected node"),
+				}
+			},
+			_ => panic!("unexpected item"),
+		}
+
+		assert!(iter.next_back().is_none());
+	}
+}

--- a/trie-db/test/src/iterator.rs
+++ b/trie-db/test/src/iterator.rs
@@ -27,7 +27,7 @@ type MemoryDB<T> = memory_db::MemoryDB<
 	DBValue,
 >;
 
-fn build_trie_db<T: TrieLayout>(
+pub(crate) fn build_trie_db<T: TrieLayout>(
 	pairs: &[(Vec<u8>, Vec<u8>)],
 ) -> (MemoryDB<T>, <T::Hash as Hasher>::Out) {
 	let mut memdb = MemoryDB::<T>::default();
@@ -41,7 +41,7 @@ fn build_trie_db<T: TrieLayout>(
 	(memdb, root)
 }
 
-fn nibble_vec<T: AsRef<[u8]>>(bytes: T, len: usize) -> NibbleVec {
+pub(crate) fn nibble_vec<T: AsRef<[u8]>>(bytes: T, len: usize) -> NibbleVec {
 	let slice = NibbleSlice::new(bytes.as_ref());
 
 	let mut v = NibbleVec::new();

--- a/trie-db/test/src/lib.rs
+++ b/trie-db/test/src/lib.rs
@@ -15,6 +15,8 @@
 //! Tests for trie-db crate.
 
 #[cfg(test)]
+mod double_ended_iterator;
+#[cfg(test)]
 mod fatdb;
 #[cfg(test)]
 mod fatdbmut;

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -18,7 +18,7 @@ use hash_db::{HashDB, Hasher, EMPTY_PREFIX};
 use hex_literal::hex;
 use memory_db::{HashKey, MemoryDB, PrefixedKey};
 use reference_trie::{
-	test_layouts, test_layouts_substrate, ExtensionLayout, HashedValueNoExtThreshold, TestTrieCache,
+	test_layouts, test_layouts_substrate, HashedValueNoExtThreshold, TestTrieCache,
 };
 use trie_db::{
 	encode_compact, CachedValue, DBValue, Lookup, NibbleSlice, RecordedForKey, Recorder, Trie,
@@ -125,8 +125,6 @@ fn double_ended_iterator_internal<T: TrieLayout>() {
 	assert_eq!(iter.next_back().unwrap().unwrap(), pairs[pairs.len() - 2].clone());
 	assert_eq!(iter.next_back().unwrap().unwrap(), pairs[2].clone());
 	assert_eq!(iter.next().unwrap().unwrap(), pairs[1].clone());
-	assert!(iter.next().is_none());
-	assert!(iter.next_back().is_none());
 }
 
 test_layouts!(iterator, iterator_internal);

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -120,11 +120,13 @@ fn double_ended_iterator_internal<T: TrieLayout>() {
 
 	let mut iter = t.iter().unwrap();
 
-	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![17], hex!("11").to_vec(),));
-	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![16], hex!("10").to_vec(),));
-	assert_eq!(iter.next().unwrap().unwrap(), (vec![1], hex!("01").to_vec(),));
-	assert_eq!(iter.next().unwrap().unwrap(), (vec![2], hex!("02").to_vec(),));
-	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![3], hex!("03").to_vec(),));
+	assert_eq!(iter.next().unwrap().unwrap(), pairs.first().unwrap().clone());
+	assert_eq!(iter.next_back().unwrap().unwrap(), pairs.last().unwrap().clone());
+	assert_eq!(iter.next_back().unwrap().unwrap(), pairs[pairs.len() - 2].clone());
+	assert_eq!(iter.next_back().unwrap().unwrap(), pairs[2].clone());
+	assert_eq!(iter.next().unwrap().unwrap(), pairs[1].clone());
+	assert!(iter.next().is_none());
+	assert!(iter.next_back().is_none());
 }
 
 test_layouts!(iterator, iterator_internal);

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -94,38 +94,6 @@ fn iterator_seek_works_internal<T: TrieLayout>() {
 	);
 }
 
-#[test]
-fn double_ended_iterator_simple_extension_layout() {
-	let pairs = vec![
-		(hex!("01").to_vec(), hex!("01").to_vec()),
-		(hex!("02").to_vec(), hex!("02").to_vec()),
-		(hex!("03").to_vec(), hex!("03").to_vec()),
-		(hex!("10").to_vec(), hex!("10").to_vec()),
-		(hex!("11").to_vec(), hex!("11").to_vec()),
-	];
-
-	let mut memdb =
-		MemoryDB::<<ExtensionLayout as TrieLayout>::Hash, PrefixedKey<_>, DBValue>::default();
-	let mut root = Default::default();
-	{
-		let mut t = TrieDBMutBuilder::<ExtensionLayout>::new(&mut memdb, &mut root).build();
-		for (x, y) in &pairs {
-			t.insert(x, y).unwrap();
-		}
-	}
-
-	let t = TrieDBBuilder::<ExtensionLayout>::new(&memdb, &root).build();
-	assert_eq!(pairs, t.iter().unwrap().map(|x| x.unwrap()).collect::<Vec<_>>());
-
-	let t = TrieDBBuilder::<ExtensionLayout>::new(&memdb, &root).build();
-
-	let mut iter = t.iter().unwrap();
-
-	assert_eq!(iter.next().unwrap().unwrap(), (vec![1], hex!("01").to_vec(),));
-	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![1, 17], hex!("11").to_vec(),));
-	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![1, 16], hex!("10").to_vec(),));
-}
-
 test_layouts!(double_ended_iterator, double_ended_iterator_internal);
 fn double_ended_iterator_internal<T: TrieLayout>() {
 	let pairs = vec![
@@ -152,9 +120,11 @@ fn double_ended_iterator_internal<T: TrieLayout>() {
 
 	let mut iter = t.iter().unwrap();
 
+	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![17], hex!("11").to_vec(),));
+	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![16], hex!("10").to_vec(),));
 	assert_eq!(iter.next().unwrap().unwrap(), (vec![1], hex!("01").to_vec(),));
-	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![1, 17], hex!("11").to_vec(),));
-	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![1, 16], hex!("10").to_vec(),));
+	assert_eq!(iter.next().unwrap().unwrap(), (vec![2], hex!("02").to_vec(),));
+	assert_eq!(iter.next_back().unwrap().unwrap(), (vec![3], hex!("03").to_vec(),));
 }
 
 test_layouts!(iterator, iterator_internal);

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -116,15 +116,15 @@ fn double_ended_iterator_internal<T: TrieLayout>() {
 	let t = TrieDBBuilder::<T>::new(&memdb, &root).build();
 	assert_eq!(pairs, t.iter().unwrap().map(|x| x.unwrap()).collect::<Vec<_>>());
 
-	let t = TrieDBBuilder::<T>::new(&memdb, &root).build();
+	let mut iter = t.into_double_ended_iter().unwrap();
 
-	let mut iter = t.iter().unwrap();
+	for i in 0..pairs.len() {
+		assert_eq!(iter.next().unwrap().unwrap(), pairs[i].clone());
+		assert_eq!(iter.next_back().unwrap().unwrap(), pairs[pairs.len() - i - 1].clone());
+	}
 
-	assert_eq!(iter.next().unwrap().unwrap(), pairs.first().unwrap().clone());
-	assert_eq!(iter.next_back().unwrap().unwrap(), pairs.last().unwrap().clone());
-	assert_eq!(iter.next_back().unwrap().unwrap(), pairs[pairs.len() - 2].clone());
-	assert_eq!(iter.next_back().unwrap().unwrap(), pairs[2].clone());
-	assert_eq!(iter.next().unwrap().unwrap(), pairs[1].clone());
+	assert!(iter.next().is_none());
+	assert!(iter.next_back().is_none());
 }
 
 test_layouts!(iterator, iterator_internal);

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -120,10 +120,12 @@ fn double_ended_iterator_internal<T: TrieLayout>() {
 
 	for i in 0..pairs.len() {
 		assert_eq!(iter.next().unwrap().unwrap(), pairs[i].clone());
-		assert_eq!(iter.next_back().unwrap().unwrap(), pairs[pairs.len() - i - 1].clone());
 	}
-
 	assert!(iter.next().is_none());
+
+	for i in (0..pairs.len()).rev() {
+		assert_eq!(iter.next_back().unwrap().unwrap(), pairs[i].clone());
+	}
 	assert!(iter.next_back().is_none());
 }
 

--- a/trie-db/test/src/triedb.rs
+++ b/trie-db/test/src/triedb.rs
@@ -94,6 +94,30 @@ fn iterator_seek_works_internal<T: TrieLayout>() {
 	);
 }
 
+test_layouts!(double_ended_iterator, double_ended_iterator_internal);
+fn double_ended_iterator_internal<T: TrieLayout>() {
+	let pairs = vec![
+		(hex!("00").to_vec(), hex!("00").to_vec()),
+		(hex!("01").to_vec(), hex!("01").to_vec()),
+	];
+
+	let mut memdb = MemoryDB::<T::Hash, PrefixedKey<_>, DBValue>::default();
+	let mut root = Default::default();
+	{
+		let mut t = TrieDBMutBuilder::<T>::new(&mut memdb, &mut root).build();
+		for (x, y) in &pairs {
+			t.insert(x, y).unwrap();
+		}
+	}
+
+	let t = TrieDBBuilder::<T>::new(&memdb, &root).build();
+
+	let mut iter = t.iter().unwrap();
+
+	assert_eq!(iter.next().unwrap().unwrap(), (hex!("00").to_vec(), hex!("00").to_vec(),));
+	assert_eq!(iter.next_back().unwrap().unwrap(), (hex!("01").to_vec(), hex!("01").to_vec(),));
+}
+
 test_layouts!(iterator, iterator_internal);
 fn iterator_internal<T: TrieLayout>() {
 	let d = vec![b"A".to_vec(), b"AA".to_vec(), b"AB".to_vec(), b"B".to_vec()];

--- a/trie-root/src/lib.rs
+++ b/trie-root/src/lib.rs
@@ -23,11 +23,7 @@ extern crate alloc;
 
 #[cfg(feature = "std")]
 mod rstd {
-	pub use std::{
-		cmp,
-		collections::{BTreeMap, VecDeque},
-		vec::Vec,
-	};
+	pub use std::{cmp, collections::BTreeMap, vec::Vec};
 }
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Closes https://github.com/paritytech/trie/issues/164

Enables bidirectional iteration by implementing the `DoubleEndedIterator` for all iterator types.

New double ended iterator structs:

- `TrieDBDoubleEndedIterator`
- `TrieDBNodeDoubleEndedIterator`
- `TrieDBKeyDoubleEndedIterator`
- `FatDBDoubleEndedIterator`

Internal iteration methods now accept a `fwd` bool flag to conditionally traverse a trie backwards or forwards (non exhaustive list).

- `TrieDBRawIterator::next_raw_item`
- `TrieDBRawIterator::seek`
- `Crumb::increment` (renamed to `Crumb::step` to better convey its behaviour)

Modifies `next_raw_item` to return middle node (i.e. a node containing child nodes) in reverse order based on iteration direction. Middle node is returned last when iterating backwards, mirroring forward iteration behaviour.

Adds new `AftExiting` status to pop crumb after returning it in `Exiting` status for backward iteration.

Library users can create one of these iterators from a `TrieDB` instance by calling the public `TrieDB::into_*` methods.

```rust
let trie = TrieDBBuilder::<T>::new(&memdb, &root).build();
// instantiates `TrieDBDoubleEndedIterator`
let mut iter = trie.into_double_ended_iter().unwrap();

// forward iteration
iter.next().unwrap().unwrap());
// backward iteration
iter.next_back()
```