### PR TITLE
HashDb trait should not imply Send and Sync

### DIFF
--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -76,7 +76,7 @@ pub trait Hasher: Sync + Send {
 /// Trait modelling a plain datastore whose key is a fixed type.
 /// The caller should ensure that a key only corresponds to
 /// one value.
-pub trait PlainDB<K, V>: Send + Sync + AsPlainDB<K, V> {
+pub trait PlainDB<K, V>: AsPlainDB<K, V> {
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
 	fn get(&self, key: &K) -> Option<V>;
@@ -125,7 +125,7 @@ impl<'a, K, V> PlainDBRef<K, V> for &'a mut dyn PlainDB<K, V> {
 }
 
 /// Trait modelling datastore keyed by a hash defined by the `Hasher`.
-pub trait HashDB<H: Hasher, T>: Send + Sync + AsHashDB<H, T> {
+pub trait HashDB<H: Hasher, T>: AsHashDB<H, T> {
 	/// Look up a given hash into the bytes that hash to it, returning None if the
 	/// hash is not known.
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T>;


### PR DESCRIPTION
The HashDB trait mandates its implementors to be Send and Sync. However, since removing this constraint doesn't affect the remaining code, I'm curious if there's a particular reason for retaining it. 
I'm particularly interested in this because I need to implement the HashDB trait for a structure within a single-threaded wasm runtime that isn't Send or Sync.
