### PR TITLE
Improve TrieCache size by reducing size_of NodeOwned

### DIFF
--- a/trie-db/src/lookup.rs
+++ b/trie-db/src/lookup.rs
@@ -275,13 +275,13 @@ where
 								.unwrap_or_else(|| MerkleValue::Hash(hash));
 							return Ok(Some(res))
 						} else {
-							match &children[partial.at(0) as usize] {
-								Some(x) => {
+							match &children.get(partial.at(0) as usize) {
+								Some(Some(x)) => {
 									partial = partial.mid(1);
 									key_nibbles += 1;
 									x
 								},
-								None => {
+								None | Some(None) => {
 									self.record(|| TrieAccess::NonExisting { full_key });
 
 									return Ok(None)
@@ -323,13 +323,13 @@ where
 								.unwrap_or_else(|| MerkleValue::Hash(hash));
 							return Ok(Some(res))
 						} else {
-							match &children[partial.at(slice.len()) as usize] {
-								Some(x) => {
+							match &children.get(partial.at(slice.len()) as usize) {
+								Some(Some(x)) => {
 									partial = partial.mid(slice.len() + 1);
 									key_nibbles += slice.len() + 1;
 									x
 								},
-								None => {
+								None | Some(None) => {
 									self.record(|| TrieAccess::NonExisting { full_key });
 
 									return Ok(None)
@@ -660,13 +660,13 @@ where
 								Ok(None)
 							}
 						} else {
-							match &children[partial.at(0) as usize] {
-								Some(x) => {
+							match &children.get(partial.at(0) as usize) {
+								Some(Some(x)) => {
 									partial = partial.mid(1);
 									key_nibbles += 1;
 									x
 								},
-								None => {
+								None | Some(None) => {
 									self.record(|| TrieAccess::NonExisting { full_key });
 
 									return Ok(None)
@@ -697,13 +697,13 @@ where
 								Ok(None)
 							}
 						} else {
-							match &children[partial.at(slice.len()) as usize] {
-								Some(x) => {
+							match &children.get(partial.at(slice.len()) as usize) {
+								Some(Some(x)) => {
 									partial = partial.mid(slice.len() + 1);
 									key_nibbles += slice.len() + 1;
 									x
 								},
-								None => {
+								None | Some(None) => {
 									self.record(|| TrieAccess::NonExisting { full_key });
 
 									return Ok(None)

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -389,7 +389,9 @@ impl<L: TrieLayout> Node<L> {
 				Node::Extension(key.into(), Self::inline_or_hash_owned(cb, storage)),
 			NodeOwned::Branch(encoded_children, val) => {
 				let mut child = |i: usize| {
-					encoded_children[i]
+					encoded_children
+						.get(i)
+						.unwrap_or(&None)
 						.as_ref()
 						.map(|child| Self::inline_or_hash_owned(child, storage))
 				};
@@ -417,7 +419,9 @@ impl<L: TrieLayout> Node<L> {
 			},
 			NodeOwned::NibbledBranch(k, encoded_children, val) => {
 				let mut child = |i: usize| {
-					encoded_children[i]
+					encoded_children
+						.get(i)
+						.unwrap_or(&None)
 						.as_ref()
 						.map(|child| Self::inline_or_hash_owned(child, storage))
 				};


### PR DESCRIPTION
NodeOwned uses static arrays to represent the children of a `NodeOwned::Branch` and `NodeOwned::NibbledBranch`, because the enum's  size is  the size of largest variant it ends up occupying 752 bytes. 

The substrate ShareTrieCache ends up keeping  a hash map with elements of NodeOwned, so it's size quickly balloons, although most of the children seem to be empty. 

The trie cache size benefits greatly from using a dynamic array instead of static one: https://github.com/paritytech/polkadot-sdk/issues/6131#issuecomment-2621222929, using westend-asset-hub, we can see a ~4 time reduction in memory size for the TrieCache.


Fixes: https://github.com/paritytech/polkadot-sdk/issues/7386