### PR TITLE
Release trie-db 0.30.0

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 hash-db = { path = "../../hash-db" , version = "0.16.0"}
 keccak-hasher = { path = "../keccak-hasher", version = "0.16.0" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.29.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.30.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.18.0" }
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 hashbrown = { version = "0.14.1", default-features = false, features = ["ahash"] }

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.16.0" }
 hash-db = { path = "../../hash-db" , version = "0.16.0"}
 memory-db = { path = "../../memory-db", version = "0.32.0" }
 trie-root = { path = "../../trie-root", version = "0.18.0" }
-trie-db = { path = "../../trie-db", version = "0.29.0" }
+trie-db = { path = "../../trie-db", version = "0.30.0" }
 criterion = "0.5.1"
 parity-scale-codec = "3.0.0"

--- a/trie-db/CHANGELOG.md
+++ b/trie-db/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## [0.30.0] - 2025-03-06
+- Improve `TrieCache` size by reducing size_of `NodeOwned` [#216](https://github.com/paritytech/trie/pull/216)
+
 ## [0.29.1] - 2024-05-24
 - Fix backward iterator seek [#215](https://github.com/paritytech/trie/pull/215)
 

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.29.1"
+version = "0.30.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -12,12 +12,12 @@ name = "bench"
 harness = false
 
 [dependencies]
-trie-db = { path = "..", version = "0.29.0"}
+trie-db = { path = "..", version = "0.30.0"}
 hash-db = { path = "../../hash-db", version = "0.16.0"}
 memory-db = { path = "../../memory-db", version = "0.32.0" }
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 trie-standardmap = { path = "../../test-support/trie-standardmap", version = "0.16.0" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.30.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }
 hex-literal = "0.4"
 criterion = "0.5.1"
 env_logger = { version = "0.10", default-features = false }

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -17,7 +17,7 @@ hash-db = { path = "../../hash-db", version = "0.16.0"}
 memory-db = { path = "../../memory-db", version = "0.32.0" }
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 trie-standardmap = { path = "../../test-support/trie-standardmap", version = "0.16.0" }
-reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }
+reference-trie = { path = "../../test-support/reference-trie", version = "0.30.0" }
 hex-literal = "0.4"
 criterion = "0.5.1"
 env_logger = { version = "0.10", default-features = false }

--- a/trie-eip1186/Cargo.toml
+++ b/trie-eip1186/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-db = { path = "../trie-db", default-features = false, version = "0.29.0"}
+trie-db = { path = "../trie-db", default-features = false, version = "0.30.0"}
 hash-db = { path = "../hash-db", default-features = false, version = "0.16.0"}
 
 [features]

--- a/trie-eip1186/test/Cargo.toml
+++ b/trie-eip1186/test/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 trie-eip1186 = { path = "..", version = "0.5.0"}
-trie-db = { path = "../../trie-db", version = "0.29.0"}
+trie-db = { path = "../../trie-db", version = "0.30.0"}
 hash-db = { path = "../../hash-db", version = "0.16.0"}
 reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }
 memory-db = { path = "../../memory-db", version = "0.32.0" }


### PR DESCRIPTION
Releasing 0.30.0 of trie-db to pick up https://github.com/paritytech/trie/pull/216