### PR TITLE
Release trie-bench 0.40.0

### DIFF
--- a/test-support/trie-bench/CHANGELOG.md
+++ b/test-support/trie-bench/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## [Unreleased]
 
+## [0.40.0] - 2025-03-07
+- chore: Release trie-db 0.30.0 [#213](https://github.com/paritytech/trie/pull/218)
+
 ## [0.39.0] - 2023-03-04
 - chore: Release trie-db 0.29.0 [#213](https://github.com/paritytech/trie/pull/213)
 

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"


### PR DESCRIPTION
Trie-bench needs to be released as well because we bumped the trie-db version and will mismatch when updating in substrate.