### PR TITLE
Replace BTreeMap usage with hashbrown hashmap

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 hash-db = { version = "0.16.0", path = "../hash-db", default-features = false }
+hashbrown = "0.15.3"
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher" }

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -30,7 +30,7 @@ use std::{
 };
 
 #[cfg(not(feature = "std"))]
-use alloc::collections::btree_map::{BTreeMap as Map, Entry};
+use hashbrown::{hash_map::Entry, HashMap as Map};
 
 #[cfg(not(feature = "std"))]
 use core::{borrow::Borrow, cmp::Eq, hash, marker::PhantomData, mem};


### PR DESCRIPTION
Discovered while profiling https://github.com/paritytech/polkadot-sdk/issues/6131#issuecomment-2891523233 with the benchmark https://github.com/paritytech/polkadot-sdk/pull/8069 that  when running in validation a big chunk of the time is spent inserting and retrieving data from the BTreeMap/BTreeSet.


This PR together with https://github.com/paritytech/polkadot-sdk/pull/8606 improve read costs with around ~40% and write costs with about ~20%