### PR TITLE
Fixed `Never Type Fallback being () Warning`

### DIFF
--- a/test-support/reference-trie/src/lib.rs
+++ b/test-support/reference-trie/src/lib.rs
@@ -1174,6 +1174,7 @@ mod tests {
 	use trie_db::{nibble_ops::NIBBLE_PER_BYTE, node::Node};
 
 	const _: fn() -> () = || {
+		#[allow(dead_code)]
 		struct AssertTrieDBRawIteratorIsSendAndSync
 		where
 			trie_db::TrieDBRawIterator<NoExtensionLayout>: Send + Sync;

--- a/trie-db/src/nibble/nibbleslice.rs
+++ b/trie-db/src/nibble/nibbleslice.rs
@@ -52,7 +52,7 @@ impl<'a> NibbleSlice<'a> {
 	}
 
 	/// Get nibble slice from a `NodeKey`.
-	pub fn from_stored(i: &NodeKey) -> NibbleSlice {
+	pub fn from_stored(i: &NodeKey) -> NibbleSlice<'_> {
 		NibbleSlice::new_offset(&i.1[..], i.0)
 	}
 
@@ -166,7 +166,7 @@ impl<'a> NibbleSlice<'a> {
 
 	/// Return `Partial` representation of this slice:
 	/// first encoded byte and following slice.
-	pub fn right(&'a self) -> Partial {
+	pub fn right(&'a self) -> Partial<'a> {
 		let split = self.offset / nibble_ops::NIBBLE_PER_BYTE;
 		let nb = (self.len() % nibble_ops::NIBBLE_PER_BYTE) as u8;
 		if nb > 0 {
@@ -237,7 +237,7 @@ impl<'a> NibbleSlice<'a> {
 	/// Return left portion of `NibbleSlice`, if the slice
 	/// originates from a full key it will be the `Prefix of
 	/// the node`.
-	pub fn left(&'a self) -> Prefix {
+	pub fn left(&'a self) -> Prefix<'a> {
 		let split = self.offset / nibble_ops::NIBBLE_PER_BYTE;
 		let ix = (self.offset % nibble_ops::NIBBLE_PER_BYTE) as u8;
 		if ix == 0 {
@@ -250,7 +250,7 @@ impl<'a> NibbleSlice<'a> {
 	/// Get [`Prefix`] representation of the inner data.
 	///
 	/// This means the entire inner data will be returned as [`Prefix`], ignoring any `offset`.
-	pub fn original_data_as_prefix(&self) -> Prefix {
+	pub fn original_data_as_prefix(&self) -> Prefix<'_> {
 		(&self.data, None)
 	}
 

--- a/trie-db/src/nibble/nibblevec.rs
+++ b/trie-db/src/nibble/nibblevec.rs
@@ -107,7 +107,7 @@ impl NibbleVec {
 	}
 
 	/// Get `Prefix` representation of this `NibbleVec`.
-	pub fn as_prefix(&self) -> Prefix {
+	pub fn as_prefix(&self) -> Prefix<'_> {
 		let split = self.len / nibble_ops::NIBBLE_PER_BYTE;
 		let pos = (self.len % nibble_ops::NIBBLE_PER_BYTE) as u8;
 		if pos == 0 {
@@ -208,7 +208,7 @@ impl NibbleVec {
 	}
 
 	/// Try to treat this `NibbleVec` as a `NibbleSlice`. Works only if there is no padding.
-	pub fn as_nibbleslice(&self) -> Option<NibbleSlice> {
+	pub fn as_nibbleslice(&self) -> Option<NibbleSlice<'_>> {
 		if self.len % nibble_ops::NIBBLE_PER_BYTE == 0 {
 			Some(NibbleSlice::new(self.inner()))
 		} else {

--- a/trie-db/src/node.rs
+++ b/trie-db/src/node.rs
@@ -154,7 +154,7 @@ pub enum ValueOwned<H> {
 
 impl<H: AsRef<[u8]> + Copy> ValueOwned<H> {
 	/// Returns self as [`Value`].
-	pub fn as_value(&self) -> Value {
+	pub fn as_value(&self) -> Value<'_> {
 		match self {
 			Self::Inline(data, _) => Value::Inline(&data),
 			Self::Node(hash) => Value::Node(hash.as_ref()),
@@ -228,7 +228,7 @@ impl Node<'_> {
 							}
 							Ok(())
 						})
-						.collect::<Result<_, _, _>>()?;
+						.collect::<Result<Vec<()>, _, _>>()?;
 					childs_owned
 				} else {
 					Vec::with_capacity(0)
@@ -256,7 +256,7 @@ impl Node<'_> {
 							}
 							Ok(())
 						})
-						.collect::<Result<_, _, _>>()?;
+						.collect::<Result<Vec<()>, _, _>>()?;
 					childs_owned
 				} else {
 					Vec::with_capacity(0)
@@ -670,7 +670,7 @@ impl<D: Borrow<[u8]>> OwnedNode<D> {
 	}
 
 	/// Construct a `Node` by borrowing data from this struct.
-	pub fn node(&self) -> Node {
+	pub fn node(&self) -> Node<'_> {
 		self.plan.build(self.data.borrow())
 	}
 }

--- a/trie-db/src/proof/verify.rs
+++ b/trie-db/src/proof/verify.rs
@@ -132,7 +132,7 @@ impl<'a, L: TrieLayout> StackEntry<'a, L> {
 		})
 	}
 
-	fn value(&self) -> Option<Value> {
+	fn value(&self) -> Option<Value<'_>> {
 		if let Some(hash) = self.next_value_hash.as_ref() {
 			Some(Value::Node(hash.as_ref()))
 		} else {


### PR DESCRIPTION
This prevents the future hard error that would occur in Rust 2024.

```bash
cargo report future-incompatibilities --id 1 --package trie-db@0.30.0
The following warnings were discovered during the build. These warnings are an
indication that the packages contain code that will become an error in a
future release of Rust. These warnings typically cover changes to close
soundness problems, unintended or undocumented behavior, or critical problems
that cannot be fixed in a backwards-compatible fashion, and are not expected
to be in wide use.

Each warning should contain a link for more information on what the warning
means and how to resolve it.

To solve this problem, you can try the following approaches:

- If the issue is not solved by updating the dependencies, a fix has to be
implemented by those dependencies. You can help with that by notifying the
maintainers of this problem (e.g. by creating a bug report) or by proposing a
fix to the maintainers (e.g. by creating a pull request):

  - trie-db@0.30.0
  - Repository: https://github.com/paritytech/trie
  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package trie-db@0.30.0`

- If waiting for an upstream fix is not an option, you can use the `[patch]`
section in `Cargo.toml` to use your own version of the dependency. For more
information, see:
https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section

The package `trie-db v0.30.0` currently triggers the following future incompatibility lints:
> warning: this function depends on never type fallback being `()`
>    --> /Users/paolo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trie-db-0.30.0/src/node.rs:206:2
>     |
> 206 | /     pub fn to_owned_node<L: TrieLayout>(
> 207 | |         &self,
> 208 | |     ) -> Result<NodeOwned<TrieHash<L>>, TrieHash<L>, CError<L>> {
>     | |_______________________________________________________________^
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
>     = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
>     = help: specify the types explicitly
> note: in edition 2024, the requirement `!: FromIterator<()>` will fail
```

Since we are there, fixed also lifetime syntax warnings and dead code warnings.