### PR TITLE
fixup! memory-db: allow changing the default hasher (#224)

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 hash-db = { version = "0.16.0", path = "../hash-db", default-features = false }
 hashbrown = "0.15.3"
-foldhash = "0.1.5"
+foldhash = { version = "0.1.5", default-features = false }
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher" }

--- a/memory-db/src/lib.rs
+++ b/memory-db/src/lib.rs
@@ -421,7 +421,7 @@ where
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 	KF: Send + Sync + KeyFunction<H>,
 	KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
-	S: BuildHasher + Default,
+	S: BuildHasher + Default + Send + Sync,
 {
 	fn get(&self, key: &H::Out) -> Option<T> {
 		match self.data.get(key.as_ref()) {
@@ -472,7 +472,7 @@ where
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 	KF: Send + Sync + KeyFunction<H>,
 	KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
-	S: BuildHasher + Default,
+	S: BuildHasher + Default + Send + Sync,
 {
 	fn get(&self, key: &H::Out) -> Option<T> {
 		PlainDB::get(self, key)
@@ -487,7 +487,7 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 	KF: KeyFunction<H> + Send + Sync,
-	S: BuildHasher + Default,
+	S: BuildHasher + Default + Send + Sync,
 {
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
 		if key == &self.hashed_null_node {
@@ -567,7 +567,7 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 	KF: KeyFunction<H> + Send + Sync,
-	S: BuildHasher + Default,
+	S: BuildHasher + Default + Send + Sync,
 {
 	fn get(&self, key: &H::Out, prefix: Prefix) -> Option<T> {
 		HashDB::get(self, key, prefix)
@@ -583,7 +583,7 @@ where
 	T: Default + PartialEq<T> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 	KF: KeyFunction<H> + Send + Sync,
 	KF::Key: Borrow<[u8]> + for<'a> From<&'a [u8]>,
-	S: BuildHasher + Default,
+	S: BuildHasher + Default + Send + Sync,
 {
 	fn as_plain_db(&self) -> &dyn PlainDB<H::Out, T> {
 		self
@@ -598,7 +598,7 @@ where
 	H: KeyHasher,
 	T: Default + PartialEq<T> + AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Send + Sync,
 	KF: KeyFunction<H> + Send + Sync,
-	S: BuildHasher + Default,
+	S: BuildHasher + Default + Send + Sync,
 {
 	fn as_hash_db(&self) -> &dyn HashDB<H, T> {
 		self


### PR DESCRIPTION
Somehow, because cargo build is using the local reference of hashdb, cargo build did not complain about:

```
error[E0277]: `S` cannot be shared between threads safely
   --> src/lib.rs:604:3
    |
604 |         self
    |         ^^^^ `S` cannot be shared between threads safely
```

But cargo publish is using the `crates.io` version and in that case we get the above errors, not completely sure why the local  crate makes a difference, but I just fixed it.

Additionally, also set the `default-features` to true for foldhash, so that no_std build in polkadot-sdk works.

