### PR TITLE
`TrieDBMutBase` added: no commit on drop

### DIFF
--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 hash-db = { path = "../../hash-db" , version = "0.16.0"}
 keccak-hasher = { path = "../keccak-hasher", version = "0.16.0" }
-trie-db = { path = "../../trie-db", default-features = false, version = "0.30.0" }
+trie-db = { path = "../../trie-db", default-features = false, version = "0.31.0" }
 trie-root = { path = "../../trie-root", default-features = false, version = "0.18.0" }
 parity-scale-codec = { version = "3.0.0", features = ["derive"] }
 hashbrown = { version = "0.14.1", default-features = false, features = ["ahash"] }

--- a/test-support/reference-trie/Cargo.toml
+++ b/test-support/reference-trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reference-trie"
-version = "0.29.1"
+version = "0.29.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Simple reference trie format"
 repository = "https://github.com/paritytech/trie/"

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -13,6 +13,6 @@ trie-standardmap = { path = "../trie-standardmap", version = "0.16.0" }
 hash-db = { path = "../../hash-db" , version = "0.16.0"}
 memory-db = { path = "../../memory-db", version = "0.34.0" }
 trie-root = { path = "../../trie-root", version = "0.18.0" }
-trie-db = { path = "../../trie-db", version = "0.30.0" }
+trie-db = { path = "../../trie-db", version = "0.31.0" }
 criterion = "0.5.1"
 parity-scale-codec = "3.0.0"

--- a/test-support/trie-bench/Cargo.toml
+++ b/test-support/trie-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trie-bench"
 description = "Standard benchmarking suite for tries"
-version = "0.42.0"
+version = "0.42.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/trie/"
 license = "Apache-2.0"

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Merkle-Patricia Trie generic over key hasher and node encoding"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -635,7 +635,7 @@ impl<'a, L: TrieLayout> Index<&'a StorageHandle> for NodeStorage<L> {
 	}
 }
 
-/// A builder for creating a [`TrieDBMut`].
+/// A builder for creating a [`TrieDBMut`] or [`TrieDBMutBase`].
 pub struct TrieDBMutBuilder<'db, L: TrieLayout> {
 	db: &'db mut dyn HashDB<L::Hash, DBValue>,
 	root: &'db mut TrieHash<L>,
@@ -738,8 +738,8 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 ///
 /// Querying the root of the trie will commit automatically.
 ///
-/// Dropping will not commit, refer to [`TrieDBMut`] for `Trie` implementation that performs
-/// `commit` on `drop`..
+/// Dropping the instance will not result in commit. Refer to [`TrieDBMut`] for `Trie`
+/// implementation that performs `commit` on `drop`.
 ///
 ///
 /// # Example
@@ -2186,9 +2186,16 @@ where
 	}
 }
 
-/// Type alias for `Trie` implementation.
+/// Type alias for `Trie` implementation using a generic `HashDB` backing database.
 ///
-/// Querying the root or dropping the trie will commit automatically.
+/// Can be used as a `TrieMut` trait object. `db()` can be used to get the backing database
+/// object.
+///
+/// Note that no changes are committed to the database until `commit` is called.
+///
+/// Querying the root or dropping the instance will commit automatically.
+///
+/// Refer to [`TrieDBMutBase`] for `Trie` implementation that does not perform `commit` on `drop`.
 pub type TrieDBMut<'a, L> = CommitOnDrop<'a, L>;
 
 /// combine two NodeKeys

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -705,7 +705,7 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 	/// This is useful when you want fine-grained control over when changes are committed, or when
 	/// you want to avoid the performance cost of committing if you're just doing temporary
 	/// operations.
-	pub fn without_commit_on_drop(mut self) -> Self {
+	pub fn disable_commit_on_drop(mut self) -> Self {
 		self.commit_on_drop = false;
 		self
 	}
@@ -713,7 +713,7 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 	/// Build the [`TrieDBMut`].
 	///
 	/// By default, the returned trie will automatically commit changes when dropped. Use
-	/// [`without_commit_on_drop`](Self::without_commit_on_drop) to disable this behavior.
+	/// [`disable_commit_on_drop`](Self::disable_commit_on_drop) to disable this behavior.
 	pub fn build(self) -> TrieDBMut<'db, L> {
 		let root_handle = NodeHandle::Hash(*self.root);
 
@@ -737,9 +737,7 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 ///
 /// Querying the root of the trie will commit automatically.
 ///
-/// Dropping the instance may or may not commit depending on how it was constructed:
-/// - Instances created with [`TrieDBMutBuilder::build`] will commit on drop.
-/// - Instances created with [`TrieDBMutBuilder::build_base`] will not commit on drop.
+/// Dropping the instance may or may not commit depending on [Self::commit_on_drop] flag.
 ///
 /// # Example
 /// ```ignore

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -22,7 +22,7 @@ use crate::{
 		NodeKey, NodeOwned, Value as EncodedValue, ValueOwned,
 	},
 	node_codec::NodeCodec,
-	rstd::{boxed::Box, convert::TryFrom, mem, ops::Index, result, vec::Vec, VecDeque},
+	rstd::{boxed::Box, convert::TryFrom, mem, ops, ops::Index, result, vec::Vec, VecDeque},
 	Bytes, CError, CachedValue, DBValue, Result, TrieAccess, TrieCache, TrieError, TrieHash,
 	TrieLayout, TrieMut, TrieRecorder,
 };
@@ -695,11 +695,14 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 		self
 	}
 
-	/// Build the [`TrieDBMut`].
-	pub fn build(self) -> TrieDBMut<'db, L> {
+	/// Build the [`TrieDBMutBase`] instance which is not commited on drop.
+	///
+	/// This instance of trie will not recompute the storage root hash unless [`commit`] method is
+	/// called explicitly.
+	pub fn build_base(self) -> TrieDBMutBase<'db, L> {
 		let root_handle = NodeHandle::Hash(*self.root);
 
-		TrieDBMut {
+		TrieDBMutBase {
 			db: self.db,
 			root: self.root,
 			cache: self.cache,
@@ -709,6 +712,23 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 			root_handle,
 		}
 	}
+
+	/// Build the [`TrieDBMut`].
+	pub fn build(self) -> TrieDBMut<'db, L> {
+		let root_handle = NodeHandle::Hash(*self.root);
+
+		let base = TrieDBMutBase {
+			db: self.db,
+			root: self.root,
+			cache: self.cache,
+			recorder: self.recorder.map(core::cell::RefCell::new),
+			storage: NodeStorage::empty(),
+			death_row: Default::default(),
+			root_handle,
+		};
+
+		CommitOnDrop::new(base)
+	}
 }
 
 /// A `Trie` implementation using a generic `HashDB` backing database.
@@ -716,7 +736,10 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 /// Use it as a `TrieMut` trait object. You can use `db()` to get the backing database object.
 /// Note that changes are not committed to the database until `commit` is called.
 ///
-/// Querying the root or dropping the trie will commit automatically.
+/// Querying the root of the trie will commit automatically.
+///
+/// Dropping will not commit, refer to [`TrieDBMut`] for `Trie` implementation that performs
+/// `commit` on `drop`..
 ///
 ///
 /// # Example
@@ -738,7 +761,7 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 /// t.remove(b"foo").unwrap();
 /// assert!(!t.contains(b"foo").unwrap());
 /// ```
-pub struct TrieDBMut<'a, L>
+pub struct TrieDBMutBase<'a, L>
 where
 	L: TrieLayout,
 {
@@ -753,7 +776,31 @@ where
 	recorder: Option<core::cell::RefCell<&'a mut dyn TrieRecorder<TrieHash<L>>>>,
 }
 
-impl<'a, L> TrieDBMut<'a, L>
+/// Wrapper around `TrieDBMutBase` that commits changes on drop.
+pub struct CommitOnDrop<'a, L: TrieLayout>(TrieDBMutBase<'a, L>);
+
+impl<'a, L: TrieLayout> CommitOnDrop<'a, L> {
+	/// Create a new `CommitOnDrop` wrapper around a given instance of `TrieDBMutBase`.
+	pub fn new(base: TrieDBMutBase<'a, L>) -> Self {
+		CommitOnDrop(base)
+	}
+}
+
+impl<'a, L: TrieLayout> ops::Deref for CommitOnDrop<'a, L> {
+	type Target = TrieDBMutBase<'a, L>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<'a, L: TrieLayout> ops::DerefMut for CommitOnDrop<'a, L> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}
+
+impl<'a, L> TrieDBMutBase<'a, L>
 where
 	L: TrieLayout,
 {
@@ -2020,7 +2067,7 @@ where
 	}
 }
 
-impl<'a, L> TrieMut<L> for TrieDBMut<'a, L>
+impl<'a, L> TrieMut<L> for TrieDBMutBase<'a, L>
 where
 	L: TrieLayout,
 {
@@ -2098,14 +2145,51 @@ where
 	}
 }
 
-impl<'a, L> Drop for TrieDBMut<'a, L>
+impl<'a, L> TrieMut<L> for CommitOnDrop<'a, L>
+where
+	L: TrieLayout,
+{
+	fn root(&mut self) -> &TrieHash<L> {
+		self.0.root()
+	}
+
+	fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
+
+	fn get<'x, 'key>(&'x self, key: &'key [u8]) -> Result<Option<DBValue>, TrieHash<L>, CError<L>>
+	where
+		'x: 'key,
+	{
+		self.0.get(key)
+	}
+
+	fn insert(
+		&mut self,
+		key: &[u8],
+		value: &[u8],
+	) -> Result<Option<Value<L>>, TrieHash<L>, CError<L>> {
+		self.0.insert(key, value)
+	}
+
+	fn remove(&mut self, key: &[u8]) -> Result<Option<Value<L>>, TrieHash<L>, CError<L>> {
+		self.0.remove(key)
+	}
+}
+
+impl<'a, L> Drop for CommitOnDrop<'a, L>
 where
 	L: TrieLayout,
 {
 	fn drop(&mut self) {
-		self.commit();
+		self.0.commit();
 	}
 }
+
+/// Type alias for `Trie` implementation.
+///
+/// Querying the root or dropping the trie will commit automatically.
+pub type TrieDBMut<'a, L> = CommitOnDrop<'a, L>;
 
 /// combine two NodeKeys
 fn combine_key(start: &mut NodeKey, end: (usize, &[u8])) {

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -22,7 +22,7 @@ use crate::{
 		NodeKey, NodeOwned, Value as EncodedValue, ValueOwned,
 	},
 	node_codec::NodeCodec,
-	rstd::{boxed::Box, convert::TryFrom, mem, ops, ops::Index, result, vec::Vec, VecDeque},
+	rstd::{boxed::Box, convert::TryFrom, mem, ops::Index, result, vec::Vec, VecDeque},
 	Bytes, CError, CachedValue, DBValue, Result, TrieAccess, TrieCache, TrieError, TrieHash,
 	TrieLayout, TrieMut, TrieRecorder,
 };
@@ -635,12 +635,13 @@ impl<'a, L: TrieLayout> Index<&'a StorageHandle> for NodeStorage<L> {
 	}
 }
 
-/// A builder for creating a [`TrieDBMut`] or [`TrieDBMutBase`].
+/// A builder for creating a [`TrieDBMut`].
 pub struct TrieDBMutBuilder<'db, L: TrieLayout> {
 	db: &'db mut dyn HashDB<L::Hash, DBValue>,
 	root: &'db mut TrieHash<L>,
 	cache: Option<&'db mut dyn TrieCache<L::Codec>>,
 	recorder: Option<&'db mut dyn TrieRecorder<TrieHash<L>>>,
+	commit_on_drop: bool,
 }
 
 impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
@@ -649,7 +650,7 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 	pub fn new(db: &'db mut dyn HashDB<L::Hash, DBValue>, root: &'db mut TrieHash<L>) -> Self {
 		*root = L::Codec::hashed_null_node();
 
-		Self { root, db, cache: None, recorder: None }
+		Self { root, db, cache: None, recorder: None, commit_on_drop: true }
 	}
 
 	/// Create a builder for constructing a new trie with the backing database `db` and `root`.
@@ -660,7 +661,7 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 		db: &'db mut dyn HashDB<L::Hash, DBValue>,
 		root: &'db mut TrieHash<L>,
 	) -> Self {
-		Self { db, root, cache: None, recorder: None }
+		Self { db, root, cache: None, recorder: None, commit_on_drop: true }
 	}
 
 	/// Use the given `cache` for the db.
@@ -695,29 +696,28 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 		self
 	}
 
-	/// Build the [`TrieDBMutBase`] instance which is not commited on drop.
+	/// Disable automatic commit on drop.
 	///
-	/// This instance of trie will not recompute the storage root hash unless [`commit`] method is
-	/// called explicitly.
-	pub fn build_base(self) -> TrieDBMutBase<'db, L> {
-		let root_handle = NodeHandle::Hash(*self.root);
-
-		TrieDBMutBase {
-			db: self.db,
-			root: self.root,
-			cache: self.cache,
-			recorder: self.recorder.map(core::cell::RefCell::new),
-			storage: NodeStorage::empty(),
-			death_row: Default::default(),
-			root_handle,
-		}
+	/// By default, [`TrieDBMut`] automatically commits changes when dropped. Calling this method
+	/// disables that behavior, requiring explicit calls to [`TrieDBMut::commit`] to persist
+	/// changes to the database.
+	///
+	/// This is useful when you want fine-grained control over when changes are committed, or when
+	/// you want to avoid the performance cost of committing if you're just doing temporary
+	/// operations.
+	pub fn without_commit_on_drop(mut self) -> Self {
+		self.commit_on_drop = false;
+		self
 	}
 
 	/// Build the [`TrieDBMut`].
+	///
+	/// By default, the returned trie will automatically commit changes when dropped. Use
+	/// [`without_commit_on_drop`](Self::without_commit_on_drop) to disable this behavior.
 	pub fn build(self) -> TrieDBMut<'db, L> {
 		let root_handle = NodeHandle::Hash(*self.root);
 
-		let base = TrieDBMutBase {
+		TrieDBMut {
 			db: self.db,
 			root: self.root,
 			cache: self.cache,
@@ -725,9 +725,8 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 			storage: NodeStorage::empty(),
 			death_row: Default::default(),
 			root_handle,
-		};
-
-		CommitOnDrop::new(base)
+			commit_on_drop: self.commit_on_drop,
+		}
 	}
 }
 
@@ -738,9 +737,9 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 ///
 /// Querying the root of the trie will commit automatically.
 ///
-/// Dropping the instance will not result in commit. Refer to [`TrieDBMut`] for `Trie`
-/// implementation that performs `commit` on `drop`.
-///
+/// Dropping the instance may or may not commit depending on how it was constructed:
+/// - Instances created with [`TrieDBMutBuilder::build`] will commit on drop.
+/// - Instances created with [`TrieDBMutBuilder::build_base`] will not commit on drop.
 ///
 /// # Example
 /// ```ignore
@@ -761,7 +760,7 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 /// t.remove(b"foo").unwrap();
 /// assert!(!t.contains(b"foo").unwrap());
 /// ```
-pub struct TrieDBMutBase<'a, L>
+pub struct TrieDBMut<'a, L>
 where
 	L: TrieLayout,
 {
@@ -774,33 +773,11 @@ where
 	cache: Option<&'a mut dyn TrieCache<L::Codec>>,
 	/// Optional trie recorder for recording trie accesses.
 	recorder: Option<core::cell::RefCell<&'a mut dyn TrieRecorder<TrieHash<L>>>>,
+	/// Whether to commit on drop.
+	commit_on_drop: bool,
 }
 
-/// Wrapper around [`TrieDBMutBase`] that commits changes on drop.
-pub struct CommitOnDrop<'a, L: TrieLayout>(TrieDBMutBase<'a, L>);
-
-impl<'a, L: TrieLayout> CommitOnDrop<'a, L> {
-	/// Creates a new [`CommitOnDrop`] wrapper around a given instance of [`TrieDBMutBase`].
-	pub fn new(base: TrieDBMutBase<'a, L>) -> Self {
-		CommitOnDrop(base)
-	}
-}
-
-impl<'a, L: TrieLayout> ops::Deref for CommitOnDrop<'a, L> {
-	type Target = TrieDBMutBase<'a, L>;
-
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
-}
-
-impl<'a, L: TrieLayout> ops::DerefMut for CommitOnDrop<'a, L> {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
-	}
-}
-
-impl<'a, L> TrieDBMutBase<'a, L>
+impl<'a, L> TrieDBMut<'a, L>
 where
 	L: TrieLayout,
 {
@@ -2067,7 +2044,7 @@ where
 	}
 }
 
-impl<'a, L> TrieMut<L> for TrieDBMutBase<'a, L>
+impl<'a, L> TrieMut<L> for TrieDBMut<'a, L>
 where
 	L: TrieLayout,
 {
@@ -2145,59 +2122,16 @@ where
 	}
 }
 
-impl<'a, L> TrieMut<L> for CommitOnDrop<'a, L>
-where
-	L: TrieLayout,
-{
-	fn root(&mut self) -> &TrieHash<L> {
-		self.0.root()
-	}
-
-	fn is_empty(&self) -> bool {
-		self.0.is_empty()
-	}
-
-	fn get<'x, 'key>(&'x self, key: &'key [u8]) -> Result<Option<DBValue>, TrieHash<L>, CError<L>>
-	where
-		'x: 'key,
-	{
-		self.0.get(key)
-	}
-
-	fn insert(
-		&mut self,
-		key: &[u8],
-		value: &[u8],
-	) -> Result<Option<Value<L>>, TrieHash<L>, CError<L>> {
-		self.0.insert(key, value)
-	}
-
-	fn remove(&mut self, key: &[u8]) -> Result<Option<Value<L>>, TrieHash<L>, CError<L>> {
-		self.0.remove(key)
-	}
-}
-
-impl<'a, L> Drop for CommitOnDrop<'a, L>
+impl<'a, L> Drop for TrieDBMut<'a, L>
 where
 	L: TrieLayout,
 {
 	fn drop(&mut self) {
-		self.0.commit();
+		if self.commit_on_drop {
+			self.commit();
+		}
 	}
 }
-
-/// Type alias for `Trie` implementation using a generic `HashDB` backing database.
-///
-/// Can be used as a [`TrieMut`] trait object. `db()` can be used to get the backing database
-/// object.
-///
-/// Querying the root or dropping the instance will commit changes.
-///
-/// Note that no changes are committed to the database until `commit` is called explicitly or
-/// implicitly.
-///
-/// Refer to [`TrieDBMutBase`] for `Trie` implementation that does not perform `commit` on `drop`.
-pub type TrieDBMut<'a, L> = CommitOnDrop<'a, L>;
 
 /// combine two NodeKeys
 fn combine_key(start: &mut NodeKey, end: (usize, &[u8])) {

--- a/trie-db/src/triedbmut.rs
+++ b/trie-db/src/triedbmut.rs
@@ -733,7 +733,7 @@ impl<'db, L: TrieLayout> TrieDBMutBuilder<'db, L> {
 
 /// A `Trie` implementation using a generic `HashDB` backing database.
 ///
-/// Use it as a `TrieMut` trait object. You can use `db()` to get the backing database object.
+/// Use it as a [`TrieMut`] trait object. You can use `db()` to get the backing database object.
 /// Note that changes are not committed to the database until `commit` is called.
 ///
 /// Querying the root of the trie will commit automatically.
@@ -776,11 +776,11 @@ where
 	recorder: Option<core::cell::RefCell<&'a mut dyn TrieRecorder<TrieHash<L>>>>,
 }
 
-/// Wrapper around `TrieDBMutBase` that commits changes on drop.
+/// Wrapper around [`TrieDBMutBase`] that commits changes on drop.
 pub struct CommitOnDrop<'a, L: TrieLayout>(TrieDBMutBase<'a, L>);
 
 impl<'a, L: TrieLayout> CommitOnDrop<'a, L> {
-	/// Create a new `CommitOnDrop` wrapper around a given instance of `TrieDBMutBase`.
+	/// Creates a new [`CommitOnDrop`] wrapper around a given instance of [`TrieDBMutBase`].
 	pub fn new(base: TrieDBMutBase<'a, L>) -> Self {
 		CommitOnDrop(base)
 	}
@@ -2188,12 +2188,13 @@ where
 
 /// Type alias for `Trie` implementation using a generic `HashDB` backing database.
 ///
-/// Can be used as a `TrieMut` trait object. `db()` can be used to get the backing database
+/// Can be used as a [`TrieMut`] trait object. `db()` can be used to get the backing database
 /// object.
 ///
-/// Note that no changes are committed to the database until `commit` is called.
+/// Querying the root or dropping the instance will commit changes.
 ///
-/// Querying the root or dropping the instance will commit automatically.
+/// Note that no changes are committed to the database until `commit` is called explicitly or
+/// implicitly.
 ///
 /// Refer to [`TrieDBMutBase`] for `Trie` implementation that does not perform `commit` on `drop`.
 pub type TrieDBMut<'a, L> = CommitOnDrop<'a, L>;

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-db-test"
-version = "0.31.0"
+version = "0.31.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-db crate"
 repository = "https://github.com/paritytech/trie"

--- a/trie-db/test/Cargo.toml
+++ b/trie-db/test/Cargo.toml
@@ -12,7 +12,7 @@ name = "bench"
 harness = false
 
 [dependencies]
-trie-db = { path = "..", version = "0.30.0"}
+trie-db = { path = "..", version = "0.31.0"}
 hash-db = { path = "../../hash-db", version = "0.16.0"}
 memory-db = { path = "../../memory-db", version = "0.34.0" }
 rand = { version = "0.8", default-features = false, features = ["small_rng"] }

--- a/trie-db/test/src/triedbmut.rs
+++ b/trie-db/test/src/triedbmut.rs
@@ -890,3 +890,100 @@ fn test_two_assets_memory_db_inner_2<T: TrieLayout>() {
 	assert_eq!(state.get(key2.as_ref()).unwrap().unwrap(), data2);
 	assert_eq!(state.get(key3.as_ref()).unwrap().unwrap(), data3);
 }
+
+/// Prepare a non-empty trie for testing commit_on_drop behavior.
+/// Returns a database and root with one committed key-value pair.
+fn prepare_test_trie<T: TrieLayout>() -> (PrefixedMemoryDB<T>, <T::Hash as Hasher>::Out) {
+	use hash_db::Hasher;
+
+	let mut memdb = PrefixedMemoryDB::<T>::default();
+	let mut root = <T::Hash as Hasher>::Out::default();
+
+	let initial_data = vec![(b"existing_key".to_vec(), b"existing_value".to_vec())];
+	populate_trie::<T>(&mut memdb, &mut root, &initial_data);
+
+	(memdb, root)
+}
+
+test_layouts!(test_commit_on_drop_disabled, test_commit_on_drop_disabled_internal);
+fn test_commit_on_drop_disabled_internal<T: TrieLayout>() {
+	let (mut memdb, mut root) = prepare_test_trie::<T>();
+	let root_before = root.clone();
+	let db_key_count_before = memdb.keys().len();
+
+	{
+		let mut trie = TrieDBMutBuilder::<T>::from_existing(&mut memdb, &mut root)
+			.without_commit_on_drop()
+			.build();
+		trie.insert(b"test_key_1", b"test_value_1").unwrap();
+		trie.insert(b"test_key_2", b"test_value_2").unwrap();
+		trie.insert(b"test_key_3", b"test_value_3").unwrap();
+	}
+
+	assert_eq!(
+		root, root_before,
+		"Root should not change after drop without commit"
+	);
+
+	let db_key_count_after = memdb.keys().len();
+	assert_eq!(
+		db_key_count_before, db_key_count_after,
+		"Database should not gain new entries after drop without commit (before: {}, after: {})",
+		db_key_count_before,
+		db_key_count_after
+	);
+}
+
+test_layouts!(test_commit_on_drop_enabled, test_commit_on_drop_enabled_internal);
+fn test_commit_on_drop_enabled_internal<T: TrieLayout>() {
+	let (mut memdb, mut root) = prepare_test_trie::<T>();
+	let root_before = root.clone();
+	let db_key_count_before = memdb.keys().len();
+
+	{
+		let mut trie = TrieDBMutBuilder::<T>::from_existing(&mut memdb, &mut root).build();
+		trie.insert(b"test_key_1", b"test_value_1").unwrap();
+		trie.insert(b"test_key_2", b"test_value_2").unwrap();
+		trie.insert(b"test_key_3", b"test_value_3").unwrap();
+	}
+
+	assert_ne!(root, root_before, "Root should change after drop with auto-commit");
+
+	let db_key_count_after = memdb.keys().len();
+	assert!(
+		db_key_count_after > db_key_count_before,
+		"Database should contain more nodes after drop with auto-commit (before: {}, after: {})",
+		db_key_count_before,
+		db_key_count_after
+	);
+}
+
+test_layouts!(test_commit_on_drop_explicit, test_commit_on_drop_explicit_internal);
+fn test_commit_on_drop_explicit_internal<T: TrieLayout>() {
+	let (mut memdb, mut root) = prepare_test_trie::<T>();
+	let root_before = root.clone();
+	let db_key_count_before = memdb.keys().len();
+
+	{
+		let mut trie = TrieDBMutBuilder::<T>::from_existing(&mut memdb, &mut root)
+			.without_commit_on_drop()
+			.build();
+		trie.insert(b"test_key_1", b"test_value_1").unwrap();
+		trie.insert(b"test_key_2", b"test_value_2").unwrap();
+		trie.insert(b"test_key_3", b"test_value_3").unwrap();
+		trie.commit();
+	}
+
+	assert_ne!(
+		root, root_before,
+		"Root should change after explicit commit"
+	);
+
+	let db_key_count_after = memdb.keys().len();
+	assert!(
+		db_key_count_after > db_key_count_before,
+		"Database should contain more nodes after explicit commit (before: {}, after: {})",
+		db_key_count_before,
+		db_key_count_after
+	);
+}

--- a/trie-db/test/src/triedbmut.rs
+++ b/trie-db/test/src/triedbmut.rs
@@ -920,17 +920,13 @@ fn test_commit_on_drop_disabled_internal<T: TrieLayout>() {
 		trie.insert(b"test_key_3", b"test_value_3").unwrap();
 	}
 
-	assert_eq!(
-		root, root_before,
-		"Root should not change after drop without commit"
-	);
+	assert_eq!(root, root_before, "Root should not change after drop without commit");
 
 	let db_key_count_after = memdb.keys().len();
 	assert_eq!(
 		db_key_count_before, db_key_count_after,
 		"Database should not gain new entries after drop without commit (before: {}, after: {})",
-		db_key_count_before,
-		db_key_count_after
+		db_key_count_before, db_key_count_after
 	);
 }
 
@@ -974,10 +970,7 @@ fn test_commit_on_drop_explicit_internal<T: TrieLayout>() {
 		trie.commit();
 	}
 
-	assert_ne!(
-		root, root_before,
-		"Root should change after explicit commit"
-	);
+	assert_ne!(root, root_before, "Root should change after explicit commit");
 
 	let db_key_count_after = memdb.keys().len();
 	assert!(

--- a/trie-db/test/src/triedbmut.rs
+++ b/trie-db/test/src/triedbmut.rs
@@ -913,7 +913,7 @@ fn test_commit_on_drop_disabled_internal<T: TrieLayout>() {
 
 	{
 		let mut trie = TrieDBMutBuilder::<T>::from_existing(&mut memdb, &mut root)
-			.without_commit_on_drop()
+			.disable_commit_on_drop()
 			.build();
 		trie.insert(b"test_key_1", b"test_value_1").unwrap();
 		trie.insert(b"test_key_2", b"test_value_2").unwrap();
@@ -962,7 +962,7 @@ fn test_commit_on_drop_explicit_internal<T: TrieLayout>() {
 
 	{
 		let mut trie = TrieDBMutBuilder::<T>::from_existing(&mut memdb, &mut root)
-			.without_commit_on_drop()
+			.disable_commit_on_drop()
 			.build();
 		trie.insert(b"test_key_1", b"test_value_1").unwrap();
 		trie.insert(b"test_key_2", b"test_value_2").unwrap();

--- a/trie-eip1186/Cargo.toml
+++ b/trie-eip1186/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-trie-db = { path = "../trie-db", default-features = false, version = "0.30.0"}
+trie-db = { path = "../trie-db", default-features = false, version = "0.31.0"}
 hash-db = { path = "../hash-db", default-features = false, version = "0.16.0"}
 
 [features]

--- a/trie-eip1186/Cargo.toml
+++ b/trie-eip1186/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-eip1186"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "EIP-1186 compliant proof generation and verification"
 repository = "https://github.com/paritytech/trie"

--- a/trie-eip1186/test/Cargo.toml
+++ b/trie-eip1186/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trie-eip1186-test"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Tests for trie-eip1186 crate"
 repository = "https://github.com/paritytech/trie"

--- a/trie-eip1186/test/Cargo.toml
+++ b/trie-eip1186/test/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 trie-eip1186 = { path = "..", version = "0.5.0"}
-trie-db = { path = "../../trie-db", version = "0.30.0"}
+trie-db = { path = "../../trie-db", version = "0.31.0"}
 hash-db = { path = "../../hash-db", version = "0.16.0"}
 reference-trie = { path = "../../test-support/reference-trie", version = "0.29.0" }
 memory-db = { path = "../../memory-db", version = "0.34.0" }


### PR DESCRIPTION
This PR adds an option to prevent `TrieDBMut` from committing implicitly on drop.

This PR extends the `TrieDBMut` implementation to provide better control over when changes are committed to the database.

Changes:
- `commit_on_drop` flag added to `TrieDBMut`,
- Added `without_commit_on_drop`  method to `TrieDBMutBuilder` which configures the builder to create a _non-commiting_ `TrieDBMut` instance for cases where commit on drop is undesired.

Part of: https://github.com/paritytech/polkadot-sdk/issues/6020