### PR TITLE
fix decode compact prefix db

### DIFF
--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -81,7 +81,7 @@ pub use crate::{
 	iter_build::{trie_visit, ProcessEncodedNode, TrieBuilder, TrieRoot, TrieRootUnhashed},
 	iterator::{TrieDBNodeIterator, TrieDBRawIterator},
 	node_codec::{NodeCodec, Partial},
-	trie_codec::{decode_compact, decode_compact_from_iter, decode_compact_from_iter_with_prefix, encode_compact},
+	trie_codec::{decode_compact, decode_compact_from_iter, encode_compact},
 };
 pub use hash_db::{HashDB, HashDBRef, Hasher};
 

--- a/trie-db/src/lib.rs
+++ b/trie-db/src/lib.rs
@@ -81,7 +81,7 @@ pub use crate::{
 	iter_build::{trie_visit, ProcessEncodedNode, TrieBuilder, TrieRoot, TrieRootUnhashed},
 	iterator::{TrieDBNodeIterator, TrieDBRawIterator},
 	node_codec::{NodeCodec, Partial},
-	trie_codec::{decode_compact, decode_compact_from_iter, encode_compact},
+	trie_codec::{decode_compact, decode_compact_from_iter, decode_compact_from_iter_with_prefix, encode_compact},
 };
 pub use hash_db::{HashDB, HashDBRef, Hasher};
 

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -29,7 +29,7 @@ use crate::{
 	nibble_ops::NIBBLE_LENGTH,
 	node::{Node, NodeHandle, NodeHandlePlan, NodePlan, OwnedNode, ValuePlan},
 	rstd::{boxed::Box, convert::TryInto, marker::PhantomData, result, sync::Arc, vec, vec::Vec},
-	CError, ChildReference, DBValue, NibbleVec, NodeCodec, Result, TrieDB, TrieDBRawIterator,
+	CError, ChildReference, DBValue, NibbleSlice, NibbleVec, NodeCodec, Result, TrieDB, TrieDBRawIterator,
 	TrieError, TrieHash, TrieLayout,
 };
 use hash_db::{HashDB, Prefix};
@@ -464,12 +464,27 @@ where
 	DB: HashDB<L::Hash, DBValue>,
 	I: IntoIterator<Item = &'a [u8]>,
 {
+	decode_compact_from_iter_with_prefix::<L, DB, I>(db, encoded, &[])
+}
+
+/// Variant of 'decode_compact' that accept an iterator of encoded nodes as input,
+/// and root prefix.
+pub fn decode_compact_from_iter_with_prefix<'a, L, DB, I>(
+	db: &mut DB,
+	encoded: I,
+	root_prefix: &[u8],
+) -> Result<(TrieHash<L>, usize), TrieHash<L>, CError<L>>
+where
+	L: TrieLayout,
+	DB: HashDB<L::Hash, DBValue>,
+	I: IntoIterator<Item = &'a [u8]>,
+{
 	// The stack of nodes through a path in the trie. Each entry is a child node of the preceding
 	// entry.
 	let mut stack: Vec<DecoderStackEntry<L::Codec>> = Vec::new();
 
 	// The prefix of the next item to be read from the slice of encoded items.
-	let mut prefix = NibbleVec::new();
+	let mut prefix = NibbleVec::from(NibbleSlice::new(root_prefix));
 
 	let mut iter = encoded.into_iter().enumerate();
 	while let Some((i, encoded_node)) = iter.next() {
@@ -516,7 +531,18 @@ where
 			let hash = last_entry
 				.attached_value
 				.as_ref()
-				.map(|value| db.insert(prefix.as_prefix(), value));
+				.map(|value| {
+					let partial_prefix_len = match &last_entry.node {
+						Node::Leaf(partial, _) | Node::NibbledBranch(partial, _, _) => {
+							prefix.append_partial(partial.right());
+							partial.len()
+						},
+						_ => 0,
+					};
+					let hash = db.insert(prefix.as_prefix(), value);
+					prefix.drop_lasts(partial_prefix_len);
+					hash
+				});
 			let node_data = last_entry.encode_node(hash.as_ref().map(|h| h.as_ref()));
 			let node_hash = db.insert(prefix.as_prefix(), node_data.as_ref());
 

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -513,21 +513,18 @@ where
 
 			// Since `advance_child_index` returned true, the preconditions for `encode_node` are
 			// satisfied.
-			let hash = last_entry
-				.attached_value
-				.as_ref()
-				.map(|value| {
-					let partial_prefix_len = match &last_entry.node {
-						Node::Leaf(partial, _) | Node::NibbledBranch(partial, _, _) => {
-							prefix.append_partial(partial.right());
-							partial.len()
-						},
-						_ => 0,
-					};
-					let hash = db.insert(prefix.as_prefix(), value);
-					prefix.drop_lasts(partial_prefix_len);
-					hash
-				});
+			let hash = last_entry.attached_value.as_ref().map(|value| {
+				let partial_prefix_len = match &last_entry.node {
+					Node::Leaf(partial, _) | Node::NibbledBranch(partial, _, _) => {
+						prefix.append_partial(partial.right());
+						partial.len()
+					},
+					_ => 0,
+				};
+				let hash = db.insert(prefix.as_prefix(), value);
+				prefix.drop_lasts(partial_prefix_len);
+				hash
+			});
 			let node_data = last_entry.encode_node(hash.as_ref().map(|h| h.as_ref()));
 			let node_hash = db.insert(prefix.as_prefix(), node_data.as_ref());
 

--- a/trie-db/src/trie_codec.rs
+++ b/trie-db/src/trie_codec.rs
@@ -29,7 +29,7 @@ use crate::{
 	nibble_ops::NIBBLE_LENGTH,
 	node::{Node, NodeHandle, NodeHandlePlan, NodePlan, OwnedNode, ValuePlan},
 	rstd::{boxed::Box, convert::TryInto, marker::PhantomData, result, sync::Arc, vec, vec::Vec},
-	CError, ChildReference, DBValue, NibbleSlice, NibbleVec, NodeCodec, Result, TrieDB, TrieDBRawIterator,
+	CError, ChildReference, DBValue, NibbleVec, NodeCodec, Result, TrieDB, TrieDBRawIterator,
 	TrieError, TrieHash, TrieLayout,
 };
 use hash_db::{HashDB, Prefix};
@@ -464,27 +464,12 @@ where
 	DB: HashDB<L::Hash, DBValue>,
 	I: IntoIterator<Item = &'a [u8]>,
 {
-	decode_compact_from_iter_with_prefix::<L, DB, I>(db, encoded, &[])
-}
-
-/// Variant of 'decode_compact' that accept an iterator of encoded nodes as input,
-/// and root prefix.
-pub fn decode_compact_from_iter_with_prefix<'a, L, DB, I>(
-	db: &mut DB,
-	encoded: I,
-	root_prefix: &[u8],
-) -> Result<(TrieHash<L>, usize), TrieHash<L>, CError<L>>
-where
-	L: TrieLayout,
-	DB: HashDB<L::Hash, DBValue>,
-	I: IntoIterator<Item = &'a [u8]>,
-{
 	// The stack of nodes through a path in the trie. Each entry is a child node of the preceding
 	// entry.
 	let mut stack: Vec<DecoderStackEntry<L::Codec>> = Vec::new();
 
 	// The prefix of the next item to be read from the slice of encoded items.
-	let mut prefix = NibbleVec::from(NibbleSlice::new(root_prefix));
+	let mut prefix = NibbleVec::new();
 
 	let mut iter = encoded.into_iter().enumerate();
 	while let Some((i, encoded_node)) = iter.next() {

--- a/trie-db/test/src/trie_codec.rs
+++ b/trie-db/test/src/trie_codec.rs
@@ -122,7 +122,13 @@ fn trie_compact_encoding_works_internal<T: TrieLayout>() {
 
 	encoded.push(Vec::new()); // Add an extra item to ensure it is not read.
 	test_decode_compact::<T>(MemoryDB::<T>::default(), &encoded, &items, root, encoded.len() - 1);
-	test_decode_compact::<T>(PrefixedMemoryDB::<T>::default(), &encoded, &items, root, encoded.len() - 1);
+	test_decode_compact::<T>(
+		PrefixedMemoryDB::<T>::default(),
+		&encoded,
+		&items,
+		root,
+		encoded.len() - 1,
+	);
 }
 
 test_layouts!(

--- a/trie-db/test/src/trie_codec.rs
+++ b/trie-db/test/src/trie_codec.rs
@@ -25,6 +25,12 @@ type MemoryDB<T> = memory_db::MemoryDB<
 	DBValue,
 >;
 
+type PrefixedMemoryDB<T> = memory_db::MemoryDB<
+	<T as TrieLayout>::Hash,
+	memory_db::PrefixedKey<<T as TrieLayout>::Hash>,
+	DBValue,
+>;
+
 fn test_encode_compact<L: TrieLayout>(
 	entries: Vec<(&'static [u8], &'static [u8])>,
 	keys: Vec<&'static [u8]>,
@@ -76,7 +82,7 @@ fn test_decode_compact<L: TrieLayout>(
 	expected_used: usize,
 ) {
 	// Reconstruct the partial DB from the compact encoding.
-	let mut db = MemoryDB::<L>::default();
+	let mut db = PrefixedMemoryDB::<L>::default();
 	let (root, used) = decode_compact::<L, _>(&mut db, encoded).unwrap();
 	assert_eq!(root, expected_root);
 	assert_eq!(used, expected_used);

--- a/trie-db/test/src/trie_codec.rs
+++ b/trie-db/test/src/trie_codec.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use hash_db::{HashDB, Hasher, EMPTY_PREFIX};
+use hash_db::{HashDB, HashDBRef, Hasher, EMPTY_PREFIX};
 use reference_trie::{test_layouts, ExtensionLayout};
 use trie_db::{
 	decode_compact, encode_compact, DBValue, NodeCodec, Recorder, Trie, TrieDBBuilder,
@@ -76,13 +76,13 @@ fn test_encode_compact<L: TrieLayout>(
 }
 
 fn test_decode_compact<L: TrieLayout>(
+	mut db: impl HashDB<L::Hash, DBValue> + HashDBRef<L::Hash, DBValue>,
 	encoded: &[Vec<u8>],
-	items: Vec<(&'static [u8], Option<DBValue>)>,
+	items: &[(&'static [u8], Option<DBValue>)],
 	expected_root: <L::Hash as Hasher>::Out,
 	expected_used: usize,
 ) {
 	// Reconstruct the partial DB from the compact encoding.
-	let mut db = PrefixedMemoryDB::<L>::default();
 	let (root, used) = decode_compact::<L, _>(&mut db, encoded).unwrap();
 	assert_eq!(root, expected_root);
 	assert_eq!(used, expected_used);
@@ -90,7 +90,7 @@ fn test_decode_compact<L: TrieLayout>(
 	// Check that lookups for all items succeed.
 	let trie = <TrieDBBuilder<L>>::new(&db, &root).build();
 	for (key, expected_value) in items {
-		assert_eq!(trie.get(key).unwrap(), expected_value);
+		assert_eq!(&trie.get(key).unwrap(), expected_value);
 	}
 }
 
@@ -121,7 +121,8 @@ fn trie_compact_encoding_works_internal<T: TrieLayout>() {
 	);
 
 	encoded.push(Vec::new()); // Add an extra item to ensure it is not read.
-	test_decode_compact::<T>(&encoded, items, root, encoded.len() - 1);
+	test_decode_compact::<T>(MemoryDB::<T>::default(), &encoded, &items, root, encoded.len() - 1);
+	test_decode_compact::<T>(PrefixedMemoryDB::<T>::default(), &encoded, &items, root, encoded.len() - 1);
 }
 
 test_layouts!(


### PR DESCRIPTION
- partial prefix for attached value was not appended
- <strike>add support for child trie root prefix</strike> (use prefixed db wrapper)
- also [backported](https://github.com/turuslan/paritytech-trie/tree/fix/decode_compact_prefix_db_0_30_0) for https://github.com/paritytech/polkadot-sdk/pull/9247