### PR TITLE
Make hash-db always a no_std library

### DIFF
--- a/hash-db/Cargo.toml
+++ b/hash-db/Cargo.toml
@@ -7,8 +7,3 @@ license = "Apache-2.0"
 categories = [ "no-std" ]
 repository = "https://github.com/paritytech/trie"
 edition = "2018"
-
-[features]
-default = ["std"]
-std = [
-]

--- a/hash-db/src/lib.rs
+++ b/hash-db/src/lib.rs
@@ -14,23 +14,13 @@
 
 //! Database of byte-slices keyed to their hash.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
-#[cfg(not(feature = "std"))]
 use core::hash;
-#[cfg(feature = "std")]
-use std::fmt::Debug;
-#[cfg(feature = "std")]
-use std::hash;
+use core::fmt::Debug;
 
-#[cfg(feature = "std")]
 pub trait MaybeDebug: Debug {}
-#[cfg(feature = "std")]
 impl<T: Debug> MaybeDebug for T {}
-#[cfg(not(feature = "std"))]
-pub trait MaybeDebug {}
-#[cfg(not(feature = "std"))]
-impl<T> MaybeDebug for T {}
 
 /// A trie node prefix, it is the nibble path from the trie root
 /// to the trie node.
@@ -205,7 +195,6 @@ impl<'a, H: Hasher, T> AsHashDB<H, T> for &'a mut dyn HashDB<H, T> {
 	}
 }
 
-#[cfg(feature = "std")]
 impl<'a, K, V> AsPlainDB<K, V> for &'a mut dyn PlainDB<K, V> {
 	fn as_plain_db(&self) -> &dyn PlainDB<K, V> {
 		&**self

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -18,9 +18,7 @@ criterion = "0.5.1"
 
 [features]
 default = ["std"]
-std = [
-  "hash-db/std",
-]
+std = []
 
 [[bench]]
 name = "bench"

--- a/test-support/keccak-hasher/Cargo.toml
+++ b/test-support/keccak-hasher/Cargo.toml
@@ -14,6 +14,4 @@ hash256-std-hasher = { path = "../../hash256-std-hasher", version = "0.15.2" }
 
 [features]
 default = ["std"]
-std = [
-  "hash-db/std",
-]
+std = []

--- a/trie-db/Cargo.toml
+++ b/trie-db/Cargo.toml
@@ -16,6 +16,5 @@ rustc-hex = { version = "2.1.0", default-features = false, optional = true }
 [features]
 default = ["std"]
 std = [
-  "hash-db/std",
   "rustc-hex",
 ]

--- a/trie-eip1186/Cargo.toml
+++ b/trie-eip1186/Cargo.toml
@@ -15,5 +15,4 @@ hash-db = { path = "../hash-db", default-features = false, version = "0.16.0"}
 default = ["std"]
 std = [
   "trie-db/std",
-  "hash-db/std",
 ]

--- a/trie-root/Cargo.toml
+++ b/trie-root/Cargo.toml
@@ -13,6 +13,4 @@ hash-db = { path = "../hash-db", default-features = false, version = "0.16.0" }
 
 [features]
 default = ["std"]
-std = [
-	"hash-db/std"
-]
+std = []


### PR DESCRIPTION
This PR removes `std` feature from `hash-db` crate, making it always a `no_std` library.

## Motivation

There is nothing in `hash-db` crate which actually depends on `std` items not present in `core`. So it makes no sense to have this Cargo feature there. Instead it can simply always be a `no_std` crate.

## Note

I think with these changes trait `MaybeDebug` doesn't make any sense and can be removed completely. In fact there is probably no need to put it as a bound on `Hasher::Out`, because it has nothing to do with caching. I case of implementing something Debug-related, explicit bound `Hasher::Out: Debug` could be used.